### PR TITLE
Use Node API to proxy fee payment methods#735

### DIFF
--- a/api/apiDefinition.js
+++ b/api/apiDefinition.js
@@ -58,6 +58,18 @@ module.exports = {
         methods: ['POST'],
         preMiddleware: [apiAuth.verifyJWTResponseMiddleware, apiCaptcha.verifyJWTResponseMiddleware],
         function: customFunctions.submitFoiRequestEmail
+      },
+      fees: {
+        methods: ['GET'],
+        function: customFunctions.getFeeDetails
+      },
+      createPayment: {
+        methods: ['POST'],
+        function: customFunctions.createPayment
+      },
+      updatePayment: {
+        methods: ['POST'],
+        function: customFunctions.updatePayment
       }
     }
   }

--- a/api/foiRequestApiService.js
+++ b/api/foiRequestApiService.js
@@ -16,6 +16,33 @@ function RequestAPI() {
           };
         return axios.post(apiUrl, data, axiosConfig);
         
-     };   
+     };
+
+     this.invokeGetFeeDetails = (apiUrl) => {
+        const axiosConfig = {
+            headers: {
+                'Content-Type': 'application/json'              
+            }
+          };
+        return axios.get(apiUrl, axiosConfig);        
+     };
+
+     this.invokeCreatePayment = (data, apiUrl) => {
+        const axiosConfig = {
+            headers: {
+                'Content-Type': 'application/json'              
+            }
+          };
+        return axios.post(apiUrl, data, axiosConfig);        
+     };
+
+     this.invokeUpdatePayment = (data, apiUrl) => {
+        const axiosConfig = {
+            headers: {
+                'Content-Type': 'application/json'              
+            }
+          };
+        return axios.put(apiUrl, data, axiosConfig);        
+     };
   };  
   module.exports = { RequestAPI };

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -110,12 +110,14 @@ export class TransomApiClientService  {
   createTransaction(transactionRequest): Observable<any> {
     const {feeCode, quantity, returnRoute} = transactionRequest
     
-    const url = this.requestManagementUrl + `/foirawrequests/${transactionRequest.requestId}/payments`;
+    const url = this.baseUrl + `/fx/createPayment?requestId=${transactionRequest.requestId}`;
 
     const obs = this.http.post(url, JSON.stringify({
-      fee_code: feeCode,
-      quantity: quantity,
-      return_route: returnRoute
+      requestData: {
+        fee_code: feeCode,
+        quantity: quantity,
+        return_route: returnRoute
+      }
     }), {
       headers: this.headers
     });
@@ -125,10 +127,12 @@ export class TransomApiClientService  {
   updateTransaction(updateTransactionRequest): Observable<any> {
     const {requestId, responseUrl, paymentId} = updateTransactionRequest;
 
-    const url = this.requestManagementUrl + `/foirawrequests/${requestId}/payments/${paymentId}`;
+    const url = this.baseUrl + `/fx/updatePayment?requestId=${requestId}&paymentId=${paymentId}`;
 
-    const obs = this.http.put(url, JSON.stringify({      
-      response_url: responseUrl
+    const obs = this.http.post(url, JSON.stringify({
+      requestData: {
+        response_url: responseUrl
+      }
     }), {
       headers: this.headers
     });
@@ -137,7 +141,7 @@ export class TransomApiClientService  {
   }
 
   getFeeDetails(feeCode: String, quantity: Number): Observable<any> {
-    const url = this.requestManagementUrl + `/fees/${feeCode}?quantity=${quantity}`
+    const url = this.baseUrl + `/fx/fees?feeCode=${feeCode}&quantity=${quantity}`
 
     const obs = this.http.get(url, {
       headers: this.headers


### PR DESCRIPTION
Used node api to proxy the fee payment methods in the UI to the python flask API. The reason behind this is that the flask API and the UI Web are in two different open shift environments.