### PR TITLE
Remove apiAuth verify

### DIFF
--- a/api/apiDefinition.js
+++ b/api/apiDefinition.js
@@ -56,7 +56,6 @@ module.exports = {
       },
       submitFoiRequestEmail: {
         methods: ['POST'],
-        preMiddleware: [apiAuth.verifyJWTResponseMiddleware],
         function: customFunctions.submitFoiRequestEmail
       },
       fees: {


### PR DESCRIPTION
apiAuth was short circuited when captcha was used. If it was decided not to do a captcha verification on this request then no need to go through the apiAuth verification (which will no longer be circuited in the case that captcha was removed and might cause errors)