### PR TITLE
Update content according to Matts request

### DIFF
--- a/web/src/app/route-components/general-info/general-info.component.html
+++ b/web/src/app/route-components/general-info/general-info.component.html
@@ -3,7 +3,6 @@
     <h2>Fees</h2>
     <ul>
       <li class="warning">A non-refundable application fee of $10 is required for all General FOI requests, <strong>for every public body selected.</strong></li>
-      <li class="warning">You will be contacted for payment of your application fee; your request <strong>will not be processed until payment is received.</strong></li>
       <li>There are no means to waive an application fee.</li>
       <li>There are no fees for personal FOI requests.</li>
       <li>
@@ -12,7 +11,7 @@
         You will have the option to pay the fee, narrow the scope of your request or request to waive the processing fee.
       </li>
     </ul>
-    <h2>Tips for avoiding fees</h2>
+    <h2>Tips for avoiding a processing fee</h2>
     <ul>
       <li>
         Ensure that you’re asking for specific records (like briefing notes)


### PR DESCRIPTION
"The second red bullet point can be deleted - since we will have online pay integration, we no longer need to tell the applicant they will be contacted. "Tips for Avoiding Fees" - should read: "Tips for avoiding a processing fee""