### PR TITLE
update dockerfile - add rebuild

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -7,7 +7,8 @@ WORKDIR /usr/src/app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm install --legacy-peer-deps --ignore-scripts
+RUN npm ci --legacy-peer-deps --ignore-scripts \
+  && npm rebuild
 
 # Copy the Angular project configuration and source files
 COPY angular.json tsconfig.json ./


### PR DESCRIPTION
Updated the Docker build to use npm ci --legacy-peer-deps --ignore-scripts followed by npm rebuild. This ensures all Angular build dependencies, including webpack, are correctly installed even when install scripts are skipped, fixing the OpenShift build failure