### PR TITLE
Web port revert to avoid friction

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -1,5 +1,5 @@
 server {
-    listen 8080;
+    listen 2015;
     server_name _;
 
     root /usr/share/nginx/html;


### PR DESCRIPTION
Revert the web port to 2015 as before to avoid friction while deploying on production envs