### PR TITLE
Ticket 2470: Duplicate Raw Request Creation Fixes

### DIFF
--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -16,6 +16,9 @@ const MAX_ATTACH_MB = 5;
 const maxAttachBytes = MAX_ATTACH_MB * 1024 * 1024;
 
 const submitFoiRequest = async (server, req, res, next) => {
+  console.count("COUNT: submitFoiRequest API CALL");
+  console.log("submitFoiRequest API DATA", req);
+  console.trace('TRACE: submitFoiRequest API CALL');
   
   const apiUrl = `${foiRequestAPIBackend}/foirawrequests`;  
 

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -110,6 +110,8 @@ export class PaymentCompleteComponent implements OnInit {
   }
 
   submitEmail() {
+    console.count('COUNT: SUBMIT PAYMENT EMAIL COMPONENT CALLED');
+    console.trace('TRACE: SUBMIT PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
       (result) => {
         if (!result.EmailSuccess) {

--- a/web/src/app/route-components/review-submit-complete/review-submit-complete.component.ts
+++ b/web/src/app/route-components/review-submit-complete/review-submit-complete.component.ts
@@ -26,13 +26,7 @@ export class ReviewSubmitCompleteComponent implements OnInit {
     this.foiRequest.requestData.requestType.youthincareparent = [];
 
     // Clear the current state!
-    const blankState: FoiRequest = {
-      requestData: {},
-    };
-    this.dataService.setCurrentState(blankState);
-    this.dataService.removeChildFileAttachment();
-    this.dataService.removePersonFileAttachment();
-    this.dataService.removeAdoptionFileAttachment();
+    this.dataService.clearState();
     this.dataService.removeAuthToken();
   }
 

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -74,12 +74,12 @@ export class ReviewSubmitComponent implements OnInit {
         this.foiRequest.requestData.requestId = result.id;
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
-        // Clear request state so a duplicate submission cannot resubmit the same data
-        this.dataService.clearState();
 
         // this.isBusy = false;
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
+          // Clear request state so a duplicate submission cannot resubmit the same data
+          this.dataService.clearState();
           this.keycloakService.logout();
         } else {
           this.base.goFoiForward();
@@ -91,11 +91,6 @@ export class ReviewSubmitComponent implements OnInit {
         alert("Temporarily unable to submit your request. Please try again in a few minutes.");
         this.captchaComponent.forceRefresh();
         this.captchaComplete = false;
-        // if (this.keycloakService.isAuthenticated()) {
-        //   this.keycloakService.logout();
-        // } else {
-        //   this.base.goFoiForward();
-        // }
       }
     );
   }

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -61,6 +61,13 @@ export class ReviewSubmitComponent implements OnInit {
   }
 
   doContinue() {
+    console.count("COUNT: REQUEST SUBMIT COMPONENT CALLED");
+    if (this.isBusy) {
+      console.trace('TRACE: REQUEST SUBMIT COMPONENT BLOCKED');
+      return;
+    }
+    console.trace('TRACE: REQUEST SUBMIT COMPONENT ALLOWED');
+    
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
       (result) => {
@@ -68,7 +75,7 @@ export class ReviewSubmitComponent implements OnInit {
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
 
-        this.isBusy = false;
+        // this.isBusy = false;
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
           this.keycloakService.logout();

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -74,6 +74,8 @@ export class ReviewSubmitComponent implements OnInit {
         this.foiRequest.requestData.requestId = result.id;
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
+        // Clear request state so a duplicate submission cannot resubmit the same data
+        this.dataService.clearState();
 
         // this.isBusy = false;
         // If the user is authenticated, logout the user

--- a/web/src/app/services/data.service.ts
+++ b/web/src/app/services/data.service.ts
@@ -293,6 +293,8 @@ export class DataService {
    * @param foiRequest - A structure containing the complete request
    */
   submitRequest(authToken: string, nonce: string, foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
+    console.count('COUNT: submitRequest FUNCTION');
+    console.trace('TRACE: submitRequest FUNCTION');
     this.apiClient.setHeader("Authorization", "Bearer " + authToken);
     if (nonce) {
       

--- a/web/src/app/services/data.service.ts
+++ b/web/src/app/services/data.service.ts
@@ -143,6 +143,14 @@ export class DataService {
     return foi;
   }
 
+  clearState() {
+    const blankState: FoiRequest = { requestData: {} };
+    this.setCurrentState(blankState);
+    this.removeChildFileAttachment();
+    this.removePersonFileAttachment();
+    this.removeAdoptionFileAttachment();
+  }
+
   setChildFileAttachment(f: File): Observable<boolean> {
     return new Observable((observer) => {
       const reader: FileReader = new FileReader();

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -94,6 +94,8 @@ export class TransomApiClientService  {
    * @param body The body to post to the request.
    */
   postFoiRequest(foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
+    console.count('COUNT: postFoiRequest FUNCTION');
+    console.trace('TRACE: postFoiRequest FUNCTION');
     const functionName = sendEmailOnly ? "submitFoiRequestEmail" : "submitFoiRequest";
     const url = this.baseUrl + `/fx/${functionName}`;
 


### PR DESCRIPTION
1. Added logs to submitFoiRequest api call which has been creating duplicate requests
2. Added isBusy guard for the code that executes submitFoiRequest api call
3. Cleared foirequest state on log out of keycloak/BCSC users. 