### PR TITLE
fix: restrict personal request route and ministry selection

### DIFF
--- a/web/src/app/route-components/ministry-confirmation/ministry-confirmation.component.html
+++ b/web/src/app/route-components/ministry-confirmation/ministry-confirmation.component.html
@@ -4,6 +4,14 @@
     <h6 *ngIf="requiresPayment" class="warning">
       *A non-refundable application fee of $10 is required for all General FOI requests, for every public body selected.
     </h6>
+    <app-alert-info *ngIf="isPersonalRequest">
+      <p>
+        For personal FOI Requests you may only submit to one Ministry at a time. If you need to submit multiple
+        different
+        personal requests you can submit a new request.
+      </p>
+    </app-alert-info>
+
 
     <div *ngIf="ministries$ | async as minis">
       <div class="form-group">

--- a/web/src/app/route-components/ministry-confirmation/ministry-confirmation.component.ts
+++ b/web/src/app/route-components/ministry-confirmation/ministry-confirmation.component.ts
@@ -27,61 +27,108 @@ export class MinistryConfirmationComponent implements OnInit {
   isENVministry: boolean = false;
   constructor(private fb: FormBuilder, private dataService: DataService, private route: Router) { }
 
-  mcfdOnlyTopicValues: string[] = [
-    "adoption",
-    "childprotectionchild",
-    "childprotectionparent",
-    "fosterparent",
-    "youthincarechild",
-    "youthincareparent",
-  ];
+  readonly personalTopicMinistryCodeMap: { [key: string]: string } = {
+    publicServiceEmployment: "PSA",
+    correctionalFacility: "PSSG",
+    incomeAssistance: "MSD",
+    adoption: "MCF",
+    childprotectionchild: "MCF",
+    childprotectionparent: "MCF",
+    fosterparent: "MCF",
+    youthincarechild: "MCF",
+    youthincareparent: "MCF",
+  };
 
-  isMcfdOnlyRequest: boolean = false;
-  readonly mcfdMinistryCode: string = "MCF";
+  readonly otherPersonalTopicValue: string = "anotherTopic";
 
-  private hasMcfdOnlyTopicSelected(): boolean {
-    const currentUrl = this.route.url || "";
+  isPersonalRequest: boolean = false;
+  isLockedPersonalMinistryRequest: boolean = false;
+  isOtherPersonalRequest: boolean = false;
+  lockedPersonalMinistryCode: string = null;
+
+  private getRequestType(): string {
+    const requestType = this.foiRequest?.requestData?.requestType;
+    return requestType?.requestType || requestType;
+  }
+
+  private getCurrentRequestTopicValue(): string {
     const currentRequestTopic = this.foiRequest?.requestData?.requestTopic?.value;
 
-    const matchesTopicSpecificRoute = this.mcfdOnlyTopicValues.some((topicValue) =>
-      currentUrl.includes(`/${topicValue}/ministry-confirmation`)
-    );
+    if (currentRequestTopic) {
+      return currentRequestTopic;
+    }
 
-    const matchesCurrentRequestTopic =
-      !!currentRequestTopic && this.mcfdOnlyTopicValues.includes(currentRequestTopic);
+    const currentUrl = this.route.url || "";
+    const personalRouteMatch = currentUrl.match(/\/personal\/([^\/]+)\/ministry-confirmation/);
 
-    return matchesTopicSpecificRoute || matchesCurrentRequestTopic;
+    return personalRouteMatch ? personalRouteMatch[1] : null;
   }
 
-
-  private isMcfdMinistry(m: any): boolean {
-    return m?.code === this.mcfdMinistryCode;
-  }
-
-  private applyMcfdOnlyMinistryRules(ministries: any[]): any[] {
-    if (!this.isMcfdOnlyRequest) {
+  private applyPersonalMinistryRules(ministries: any[]): any[] {
+    if (this.isLockedPersonalMinistryRequest) {
       ministries.forEach((m) => {
-        m.disabled = false;
+        const isLockedMinistry = m.code === this.lockedPersonalMinistryCode;
+        m.selected = isLockedMinistry;
+        m.defaulted = isLockedMinistry;
+        m.disabled = true;
       });
+
       return ministries;
     }
 
+    if (this.isOtherPersonalRequest) {
+      return this.applyOtherPersonalMinistryRules(ministries);
+    }
+
     ministries.forEach((m) => {
-      const isMcfd = this.isMcfdMinistry(m);
-      m.selected = isMcfd;
-      m.defaulted = isMcfd;
-      m.disabled = !isMcfd;
+      m.disabled = false;
     });
 
     return ministries;
   }
+
+  private applyOtherPersonalMinistryRules(ministries: any[]): any[] {
+    const selectedMinistries = ministries.filter((m) => m.selected);
+
+    if (selectedMinistries.length > 1) {
+      const selectedMinistry = selectedMinistries[0];
+
+      ministries.forEach((m) => {
+        m.selected = m.code === selectedMinistry.code;
+      });
+    }
+
+    const hasSelectedMinistry = ministries.some((m) => m.selected);
+
+    ministries.forEach((m) => {
+      m.defaulted = false;
+      m.disabled = hasSelectedMinistry && !m.selected;
+    });
+
+    return ministries;
+  }
+
+  private refreshSelectedMinistryFlags(ministries: any[]): void {
+    this.isEAOministry = !!ministries.find((m) => m.code === "EAO" && m.selected);
+    this.isENVministry = !!ministries.find((m) => m.code === "ENV" && m.selected);
+    this.isforestministry = !!ministries.find((m) => m.code === "FOR" && m.selected);
+  }
+
+
 
   ngOnInit() {
     this.foiRequest = this.dataService.getCurrentState(this.targetKey);
     this.defaultMinistry = this.foiRequest.requestData[this.targetKey].defaultMinistry;
     let selectedMinistry = this.foiRequest.requestData[this.targetKey].selectedMinistry;
     this.requiresPayment = this.foiRequest.requestData.requestType.requestType === "general";
-    this.isMcfdOnlyRequest = this.hasMcfdOnlyTopicSelected();
+    const currentRequestTopicValue = this.getCurrentRequestTopicValue();
+
+    this.isPersonalRequest = this.getRequestType() === "personal" || this.route.url.includes("/personal/");
+    this.lockedPersonalMinistryCode = this.isPersonalRequest
+      ? this.personalTopicMinistryCodeMap[currentRequestTopicValue]
+      : null;
+    this.isLockedPersonalMinistryRequest = !!this.lockedPersonalMinistryCode;
+    this.isOtherPersonalRequest = this.isPersonalRequest && currentRequestTopicValue === this.otherPersonalTopicValue;
 
     // Fetch Ministries from the data service.
     this.ministries$ = this.dataService.getMinistries().pipe(
@@ -106,7 +153,11 @@ export class MinistryConfirmationComponent implements OnInit {
             this.isforestministry = false;
           }
         });
-        return this.applyMcfdOnlyMinistryRules(ministries);
+
+        ministries = this.applyPersonalMinistryRules(ministries);
+        this.refreshSelectedMinistryFlags(ministries);
+
+        return ministries;
       }),
       map((ministries) => {
         this.base.continueDisabled = !ministries.find((m) => m.selected);
@@ -126,25 +177,17 @@ export class MinistryConfirmationComponent implements OnInit {
   }
 
   selectMinistry(m: any) {
-    if (this.isMcfdOnlyRequest) {
+    if (this.isLockedPersonalMinistryRequest) {
       return;
     }
+
     m.selected = !m.selected;
-    if (m.code === "EAO" && m.selected === true) {
-      this.isEAOministry = true;
-    } else if (m.code === "EAO" && m.selected === false) {
-      this.isEAOministry = false;
+
+    if (this.isOtherPersonalRequest) {
+      this.applyOtherPersonalMinistryRules(this.ministries);
     }
-    if (m.code === "ENV" && m.selected === true) {
-      this.isENVministry = true;
-    } else if (m.code === "ENV" && m.selected === false) {
-      this.isENVministry = false;
-    }
-    if (m.code === "FOR" && m.selected === true) {
-      this.isforestministry = true;
-    } else if (m.code === "FOR" && m.selected === false) {
-      this.isforestministry = false;
-    }
+
+    this.refreshSelectedMinistryFlags(this.ministries);
     this.setContinueDisabled();
   }
 

--- a/web/src/app/route-components/request-topic/request-topic.component.html
+++ b/web/src/app/route-components/request-topic/request-topic.component.html
@@ -1,21 +1,22 @@
 <foi-base [showInfo]="false" (continue)="doContinue()" (goBack)="doGoBack()">
   <div class="foi-content">
     <h2>What kinds of records are you looking for?</h2>
-    <hr/>
+    <hr />
     <form [formGroup]="foiForm" novalidate (ngSubmit)="doContinue()">
-      <p><em>Select the corresponding categories of records you are requesting (the more you select the larger your resulting request will be)</em></p>
+      <p><em>Select the corresponding categories of records you are requesting (the more you select the larger your
+          resulting request will be)</em></p>
       <div *ngIf="(yourselftopics | async) as topics">
         <div class="form-group" *ngFor="let topic of topics">
           <label>
-            <input type="checkbox" [value]="topic" [checked]="topic.selected"
-              (change)="selecttopic(topic,$event.target.checked)" />
+            <input type="checkbox" [value]="topic" [checked]="topic.selected" [disabled]="isTopicDisabled(topic)"
+              (change)="selecttopic(topic, $event.target.checked)" />
             <div class="optiontext" [innerHTML]="topic.text"></div>
           </label>
         </div>
       </div>
       <div class="form-group warningsection">
         <h2>Are you looking for these types of records?</h2>
-        <br/>
+        <br />
         <div class="subgroup">
           <div>
             <h5><strong>Police Records from a Police visit?</strong></h5>
@@ -42,8 +43,10 @@
           </div>
           <br />
           <div>
-            <h5><strong>Court Records and Transcripts?</strong></h5>            
-            We do not hold these records. You can get copies of your court records at <a href="https://justice.gov.bc.ca/cso/index.do" target="_blank" rel="noopener">https://justice.gov.bc.ca/cso/index.do</a>
+            <h5><strong>Court Records and Transcripts?</strong></h5>
+            We do not hold these records. You can get copies of your court records at <a
+              href="https://justice.gov.bc.ca/cso/index.do" target="_blank"
+              rel="noopener">https://justice.gov.bc.ca/cso/index.do</a>
           </div>
         </div>
       </div>

--- a/web/src/app/route-components/request-topic/request-topic.component.scss
+++ b/web/src/app/route-components/request-topic/request-topic.component.scss
@@ -19,3 +19,8 @@
   display: inline;
   padding-left: 5px;;
 }
+
+.disabled-topic-option {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/web/src/app/route-components/request-topic/request-topic.component.ts
+++ b/web/src/app/route-components/request-topic/request-topic.component.ts
@@ -29,6 +29,50 @@ export class RequestTopicComponent implements OnInit {
     "youthincarechild",
     "youthincareparent",
   ];
+
+  childrenAndFamilyTopicValues: string[] = [
+    "adoption",
+    "childprotectionchild",
+    "childprotectionparent",
+    "fosterparent",
+    "youthincarechild",
+    "youthincareparent",
+  ];
+
+  singleRouteTopicValues: string[] = [
+    "publicServiceEmployment",
+    "correctionalFacility",
+    "incomeAssistance",
+    "anotherTopic",
+  ];
+
+  private isChildrenAndFamilyTopic(topic: any): boolean {
+    return this.childrenAndFamilyTopicValues.includes(topic?.value);
+  }
+
+  private getSelectedTopics(): any[] {
+    return this.topics ? this.topics.filter((topic) => topic.selected) : [];
+  }
+
+  isTopicDisabled(topic: any): boolean {
+    const selectedTopics = this.getSelectedTopics();
+
+    if (selectedTopics.length === 0) {
+      return false;
+    }
+
+    const selectedChildrenAndFamily = selectedTopics.some((selectedTopic) =>
+      this.isChildrenAndFamilyTopic(selectedTopic)
+    );
+
+    if (selectedChildrenAndFamily) {
+      return !this.isChildrenAndFamilyTopic(topic);
+    }
+
+    const selectedTopic = selectedTopics[0];
+    return topic.value !== selectedTopic.value;
+  }
+
   constructor(
     private fb: FormBuilder,
     private dataService: DataService,
@@ -98,6 +142,10 @@ export class RequestTopicComponent implements OnInit {
   }
 
   selecttopic(item: any, _checked) {
+    if (this.isTopicDisabled(item) && !item.selected) {
+      return;
+    }
+
     item.selected = !item.selected;
     let current = this.foiRequest.requestData.selectedtopics.find((st) => st.value === item.value);
     const itemindex: number = this.foiRequest.requestData.selectedtopics.indexOf(current);


### PR DESCRIPTION
## Summary

Restricts personal request topic and ministry selection to reduce cross-contamination between personal request types.

## Changes

* On the personal request topic screen:

  * Selecting Employment, Correctional Facility, Income Assistance, or Other disables the other topic options.
  * Selecting a Children and Family option only allows other Children and Family options to remain selectable.
  * Unselecting the selected option re-enables the available topic options.

* On the ministry selection screen:

  * Employment requests default to BC Public Service Agency and cannot be changed.
  * Correctional Facility requests default to Public Safety and Solicitor General and cannot be changed.
  * Income Assistance requests default to Social Development and Poverty Reduction and cannot be changed.
  * Children and Family requests default to Children and Family Development and cannot be changed.
  * Other personal requests allow only one ministry or agency to be selected at a time.
  * Unselecting a ministry on the Other path allows the user to choose another ministry.

* Adds a personal-request banner on the ministry selection screen:

  * “For personal FOI Requests you may only submit to one Ministry at a time. If you need to submit multiple different personal requests you can submit a new request.”