### PR TITLE
feat(5201): add law firm litigation check flow for general requests

### DIFF
--- a/api/emailLayout.js
+++ b/api/emailLayout.js
@@ -2,30 +2,30 @@
  * Keep the email layout functions together, outside of index.js
  */
 function EmailLayout() {
-  this.table = function(rows) {
+  this.table = function (rows) {
     return `<table width="95%" border="0" cellpadding="5" cellspacing="0"><tbody
           style="font-size:12px;font-family:sans-serif;background-color:#fff;"
     >${rows}</tbody></table>\n`;
   };
 
-  this.tableHeader = function(label) {
+  this.tableHeader = function (label) {
     return `<tr><th style="font-size:14px;font-weight:bold;background-color:#eee;border-bottom:1px solid #dfdfdf;text-align:left;padding:7px 7px">${label}</th></tr>\n`;
   };
 
-  this.tableRow = function(label, value) {
+  this.tableRow = function (label, value) {
     return `<tr><td style="font-weight:bold;background-color:#eaf2fa;">${label}</td></tr>
             <tr><td style="padding-left:20px;">${value}</td></tr>\n`;
   };
 
-  this.tableRowNoLabel = function(value) {
+  this.tableRowNoLabel = function (value) {
     return `<tr><td style="padding-left:20px;">${value}</td></tr>\n`;
   };
 
-  this.dateFormat = function(isoDateStr) {
+  this.dateFormat = function (isoDateStr) {
     // HTML5 date is ALWAYS formatted yyyy-mm-dd.
     // ISO Date is ALWAYS formatted yyyy-mm-ddT00:00:00.000Z.
     let result = isoDateStr || 'n/a';
-    if (isoDateStr){
+    if (isoDateStr) {
       const dt = new Date(isoDateStr);
       if (!Number.isNaN(dt.getTime())) {
         const year = dt.getFullYear();
@@ -43,7 +43,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.joinBySpace = function(...strArr) {
+  this.joinBySpace = function (...strArr) {
     return strArr
       .join(' ')
       .replace(/\s+/g, ' ')
@@ -51,18 +51,17 @@ function EmailLayout() {
   };
 
   this.getAuthorisedDetailsTable = function (data) {
-    let result =''
+    let result = ''
     result += this.tableRow('Given Names of requestor', data.firstName);
     result += this.tableRow('Last Name of requestor', data.lastName);
-    const anchor = `<a href="mailto:${data.email}" target="_blank">${
-      data.email
-    }</a>`;
+    const anchor = `<a href="mailto:${data.email}" target="_blank">${data.email
+      }</a>`;
     result += this.tableRow('Email  of requestor', anchor);
     // DOB no longer comes from BCSC
     //result += this.tableRow('Date Of Birth of the Submitter', data.birthDate);
     return result
   }
-  this.general = function(data) {
+  this.general = function (data) {
     let result = this.tableHeader('Request Description');
     // Removed Topic from the generated email body.
     // if (data.topic) {
@@ -103,7 +102,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.ministry = function(data) {
+  this.ministry = function (data) {
     let result = this.tableHeader('Ministry or Agency');
 
     let ministryContent = '';
@@ -123,7 +122,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.personal = function(data ,isAuthorised) {
+  this.personal = function (data, isAuthorised) {
     // if isAuthorised , dont print the firstName and LastName
     let result = this.tableHeader('Contact Information');
     if (!isAuthorised) {
@@ -161,7 +160,66 @@ function EmailLayout() {
     return result;
   };
 
-  this.anotherInformation = function(data) {
+  this.lawFirmLegalDetails = function (contactInfo, legalProceedingDetails) {
+    if (typeof contactInfo.isLawFirm !== 'boolean') {
+      return '';
+    }
+
+    let result = this.tableHeader('Law Firm Legal Proceeding Details');
+
+    result += this.tableRow('Are you a law firm?', contactInfo.isLawFirm ? 'Yes' : 'No');
+
+    if (!contactInfo.isLawFirm) {
+      return result;
+    }
+
+    result += this.tableRow(
+      'Are you involved in a legal proceeding with the B.C. Government?',
+      contactInfo.isInvolvedInLegalProceeding ? 'Yes' : 'No'
+    );
+
+    if (contactInfo.isInvolvedInLegalProceeding === false) {
+      result += this.tableRow(
+        'Section 3(5)(e) FOIPPA Statement',
+        'Section 3(5)(e) of the Freedom of Information and Protection of Privacy Act (FOIPPA) provides that a record will be excluded from Part 2 of FOIPPA, and will not be disclosed through the Freedom of Information process, if the government of B.C. is required by law to produce, list, or identify it to the applicant (or their principal or client) as part of a proceeding.'
+      );
+
+      result += this.tableRow(
+        'Certification',
+        'I certify that, to the best of my knowledge, the Government of BC is not required by law to produce, list, or identify the requested records to me (or my client) because of a legal proceeding.'
+      );
+
+      result += this.tableRow('Certified by', contactInfo.legalProceedingCertificationName);
+    }
+
+    if (contactInfo.isInvolvedInLegalProceeding === true) {
+      result += this.tableRow('Court or tribunal', contactInfo.courtOrTribunal);
+
+      if (contactInfo.courtOrTribunalFileNumber) {
+        result += this.tableRow('Court or tribunal file number', contactInfo.courtOrTribunalFileNumber);
+      }
+
+      result += this.tableRow('Type of legal proceeding', contactInfo.legalProceedingType);
+
+      if (typeof legalProceedingDetails.isRequestRelatedToProceeding === 'boolean') {
+        result += this.tableRow(
+          'Is your request for records related to the proceeding involving the B.C. Government?',
+          legalProceedingDetails.isRequestRelatedToProceeding ? 'Yes' : 'No'
+        );
+      }
+
+      if (typeof legalProceedingDetails.isPartyToProceeding === 'boolean') {
+        result += this.tableRow(
+          'Are you a party to the proceeding involving the B.C. Government?',
+          legalProceedingDetails.isPartyToProceeding ? 'Yes' : 'No'
+        );
+      }
+    }
+
+    return result;
+  };
+
+  this.anotherInformation = function (data) {
     let result = this.tableHeader('Another Person Information');
     result += this.tableRow(
       'Name',
@@ -176,7 +234,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.childInformation = function(data) {
+  this.childInformation = function (data) {
     let result = this.tableHeader('Child Information');
     result += this.tableRow(
       'Name',
@@ -191,70 +249,60 @@ function EmailLayout() {
     return result;
   };
 
-  this.requesttopicsubpartcontent = function(mainoptions)
-  {
+  this.requesttopicsubpartcontent = function (mainoptions) {
 
-    let topicvalue=''
-    mainoptions.forEach(mainoption=>{
-      let selectedsuboptions =''
-      if(mainoption!=undefined)
-      {
-        
-      mainoption.suboptions.forEach(suboption =>{
+    let topicvalue = ''
+    mainoptions.forEach(mainoption => {
+      let selectedsuboptions = ''
+      if (mainoption != undefined) {
 
-        if(suboption.selected === true)
-        {
-         
-          selectedsuboptions += `${suboption.option}, ` 
-          
-        }
-      })
-       
-    }
-    let mainoptionvalue = mainoption.mainoptionvalue !=undefined ?mainoption.mainoptionvalue : mainoption.mainoption;
-      topicvalue+= `<b>${mainoptionvalue}</b> : ${selectedsuboptions.replace(/,\s*$/, "")} </br>`
-      
+        mainoption.suboptions.forEach(suboption => {
+
+          if (suboption.selected === true) {
+
+            selectedsuboptions += `${suboption.option}, `
+
+          }
+        })
+
+      }
+      let mainoptionvalue = mainoption.mainoptionvalue != undefined ? mainoption.mainoptionvalue : mainoption.mainoption;
+      topicvalue += `<b>${mainoptionvalue}</b> : ${selectedsuboptions.replace(/,\s*$/, "")} </br>`
+
     });
 
     return topicvalue;
 
   }
 
-  this.requesttopic = function(topics, adoption, childprotectionchild,childprotectionparent,fosterparent,youthincarechild,youthincareparent)
-  {
+  this.requesttopic = function (topics, adoption, childprotectionchild, childprotectionparent, fosterparent, youthincarechild, youthincareparent) {
     let result = this.tableHeader('MCFD Records');
 
-    topics.forEach(topic =>{
+    topics.forEach(topic => {
 
       let topicvalue = ""
 
-      if(topic.value === "adoption")
-      {
+      if (topic.value === "adoption") {
         topicvalue = this.requesttopicsubpartcontent(adoption)
       }
 
-      if(topic.value === "childprotectionchild")
-      {
+      if (topic.value === "childprotectionchild") {
         topicvalue = this.requesttopicsubpartcontent(childprotectionchild)
       }
 
-      if(topic.value === "childprotectionparent")
-      {
+      if (topic.value === "childprotectionparent") {
         topicvalue = this.requesttopicsubpartcontent(childprotectionparent)
       }
 
-      if(topic.value === "fosterparent")
-      {
+      if (topic.value === "fosterparent") {
         topicvalue = this.requesttopicsubpartcontent(fosterparent)
       }
 
-      if(topic.value === "youthincarechild")
-      {
+      if (topic.value === "youthincarechild") {
         topicvalue = this.requesttopicsubpartcontent(youthincarechild)
       }
 
-      if(topic.value === "youthincareparent")
-      {
+      if (topic.value === "youthincareparent") {
         topicvalue = this.requesttopicsubpartcontent(youthincareparent)
       }
 
@@ -263,13 +311,13 @@ function EmailLayout() {
         topicvalue)
 
 
-      });
+    });
 
     return result;
-    
+
   }
 
-  this.adoptiveParents = function(data) {
+  this.adoptiveParents = function (data) {
     const mother = this.joinBySpace(data.motherFirstName, data.motherLastName);
     const father = this.joinBySpace(data.fatherFirstName, data.fatherLastName);
     let result = '';
@@ -281,7 +329,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.contact = function(data , isAuthorised) {
+  this.contact = function (data, isAuthorised) {
     let result = '';
     if (data.phonePrimary) {
       result += this.tableRow('Phone (primary)', data.phonePrimary);
@@ -290,9 +338,8 @@ function EmailLayout() {
       result += this.tableRow('Phone (secondary)', data.phoneSecondary);
     }
     if (data.email && !isAuthorised) {
-      const anchor = `<a href="mailto:${data.email}" target="_blank">${
-        data.email
-      }</a>`;
+      const anchor = `<a href="mailto:${data.email}" target="_blank">${data.email
+        }</a>`;
       result += this.tableRow('Email', anchor);
     }
     if (data.address) {
@@ -313,7 +360,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.about = function(data) {
+  this.about = function (data) {
     let result = '';
     let selected = [];
     if (data.yourself) {
@@ -331,7 +378,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.requestInformation = function(data) {
+  this.requestInformation = function (data) {
     let result = this.tableHeader('Request Information');
     result += this.tableRow(
       'Request id',
@@ -341,7 +388,7 @@ function EmailLayout() {
     return result;
   };
 
-  this.paymentInformation = function(data) {
+  this.paymentInformation = function (data) {
     let result = this.tableHeader('Payment Information');
 
     if (data.transactionNumber) {
@@ -356,16 +403,16 @@ function EmailLayout() {
     return result;
   };
 
-  this.renderEmail = function(data ,isAuthorised ,authorisedDetails) {
+  this.renderEmail = function (data, isAuthorised, authorisedDetails) {
     let content = this.tableHeader('Request Records');
-      this.table()
+    this.table()
     if (isAuthorised) {
       content += this.tableRow(
-        'Requestor identity verification','BC Services Card'
+        'Requestor identity verification', 'BC Services Card'
       );
 
       content += this.tableRow(
-       'Verified details',this.table(this.getAuthorisedDetailsTable(authorisedDetails))
+        'Verified details', this.table(this.getAuthorisedDetailsTable(authorisedDetails))
       );
 
     }
@@ -374,7 +421,7 @@ function EmailLayout() {
       data.requestData.requestType.requestType
     );
 
-    
+
 
     // Request is About
     data.requestData.selectAbout = data.requestData.selectAbout || {};
@@ -386,12 +433,11 @@ function EmailLayout() {
       );
     }
 
-    if(data.requestData.selectAbout.yourself)
-    { 
-      content += this.requesttopic(data.requestData.selectedtopics,data.requestData.requestType.adoption,
-        data.requestData.requestType.childprotectionchild,data.requestData.requestType.childprotectionparent,
-        data.requestData.requestType.fosterparent,data.requestData.requestType.youthincarechild,data.requestData.requestType.youthincareparent
-        )    
+    if (data.requestData.selectAbout.yourself) {
+      content += this.requesttopic(data.requestData.selectedtopics, data.requestData.requestType.adoption,
+        data.requestData.requestType.childprotectionchild, data.requestData.requestType.childprotectionparent,
+        data.requestData.requestType.fosterparent, data.requestData.requestType.youthincarechild, data.requestData.requestType.youthincareparent
+      )
     }
 
     // if we have 'childInformation' then include the block
@@ -403,18 +449,22 @@ function EmailLayout() {
     // Ministry or Agency
     content += this.ministry(data.requestData.ministry || {});
     // Contact Information
-    content += this.personal(data.requestData.contactInfo || {} ,isAuthorised);
-    content += this.contact(data.requestData.contactInfoOptions || {},isAuthorised);
+    content += this.personal(data.requestData.contactInfo || {}, isAuthorised);
+    content += this.lawFirmLegalDetails(
+      data.requestData.contactInfo || {},
+      data.requestData.legalProceedingDetails || {}
+    );
+    content += this.contact(data.requestData.contactInfoOptions || {}, isAuthorised);
     // Adoptive Parents
     content += this.adoptiveParents(data.requestData.adoptiveParents || {});
     // Request info
-    if(data.requestData.requestId) {
+    if (data.requestData.requestId) {
       content += this.requestInformation({
         requestId: data.requestData.requestId
       })
     }
     // Payment info
-    if(data.requestData.paymentInfo) {
+    if (data.requestData.paymentInfo) {
       content += this.paymentInformation(data.requestData.paymentInfo);
     }
 
@@ -433,15 +483,15 @@ function EmailLayout() {
 
 function ConfirmationEmailLayout() {
 
-  this.paymentInfo = function(paymentInfoData) {
+  this.paymentInfo = function (paymentInfoData) {
 
-    if(!paymentInfoData || Object.keys(paymentInfoData).length === 0) {
+    if (!paymentInfoData || Object.keys(paymentInfoData).length === 0) {
       return ``;
     }
-    
+
     let result = `<p>Your transaction details are as follows:</p>`;
 
-    if(paymentInfoData.transactionNumber) {
+    if (paymentInfoData.transactionNumber) {
       result = result + `<p>Transaction Number: ${paymentInfoData.transactionNumber}</p>`;
     }
 
@@ -453,13 +503,13 @@ function ConfirmationEmailLayout() {
 
     if (paymentInfoData.amount) {
       result =
-        result + `<p>Amount: $${paymentInfoData.amount}</p>`; 
+        result + `<p>Amount: $${paymentInfoData.amount}</p>`;
     }
-    
+
     return result;
   }
 
-  this.renderEmail = function(data) {
+  this.renderEmail = function (data) {
     let content = `
 		<div style='width:40em;font-family:sans-serif;'>
 			<p>This email confirms your recent payment on ${data.paymentInfo.transactionDate} for your FOI Request Submission.</p>

--- a/api/test/emailLayout.spec.js
+++ b/api/test/emailLayout.spec.js
@@ -1,11 +1,12 @@
 'use strict';
 const sinon = require('sinon');
-const EmailLayout = require('../emailLayout');
+const { EmailLayout } = require('../emailLayout');
 const chai = require('chai');
+const chaiString = require('chai-string');
 const chaiAsPromised = require('chai-as-promised');
 
-chai.use(require('chai-string'));
-chai.use(chaiAsPromised);
+chai.use(chaiString.default || chaiString);
+chai.use(chaiAsPromised.default || chaiAsPromised);
 const expect = chai.expect;
 
 // Initialized before each test
@@ -41,8 +42,8 @@ function scrubAttribs(result) {
   return result;
 }
 
-describe('emailLayout', function() {
-  beforeEach(function() {
+describe('emailLayout', function () {
+  beforeEach(function () {
     emailLayout = new EmailLayout();
 
     sampleRequestData = {
@@ -96,6 +97,7 @@ describe('emailLayout', function() {
         text: 'Adoption',
         ministryCode: 'MCF'
       },
+      selectedtopics: [],
       descriptionTimeframe: {
         description: 'Foosball tables',
         fromDate: timezoneAdjust('2019-03-21T00:00:00.000Z'),
@@ -123,32 +125,39 @@ describe('emailLayout', function() {
     };
   });
 
-  it('should exist and have the expected functions', function() {
+  it('should exist and have the expected functions', function () {
     expect(emailLayout).to.exist;
     // Make sure all the functions are as expected
-    const fx = [
-      'table',
-      'tableHeader',
-      'tableRow',
-      'dateFormat',
-      'joinBySpace',
-      'general',
-      'ministry',
-      'personal',
-      'anotherInformation',
-      'adoptiveParents',
-      'childInformation',
-      'contact',
-      'about',
-      'renderEmail'
-    ];
+   const fx = [
+  'table',
+  'tableHeader',
+  'tableRow',
+  'tableRowNoLabel',
+  'dateFormat',
+  'joinBySpace',
+  'getAuthorisedDetailsTable',
+  'general',
+  'ministry',
+  'personal',
+  'lawFirmLegalDetails',
+  'anotherInformation',
+  'adoptiveParents',
+  'childInformation',
+  'requesttopicsubpartcontent',
+  'requesttopic',
+  'contact',
+  'about',
+  'requestInformation',
+  'paymentInformation',
+  'renderEmail',
+];
     fx.map(fxName => {
       expect(emailLayout[fxName]).to.exist;
     });
-    expect(Object.keys(emailLayout).length).to.equal(15);
+    expect(Object.keys(emailLayout).length).to.equal(21);
   });
 
-  it('should render table and headers', function() {
+  it('should render table and headers', function () {
     let table = emailLayout.table('Hello World');
     // strip any newlines!
     table = table.replace(/\r\n|\n|\r/gm, '');
@@ -157,7 +166,7 @@ describe('emailLayout', function() {
     expect(table).to.endsWith('</table>');
   });
 
-  it('should render table headers', function() {
+  it('should render table headers', function () {
     let table = emailLayout.tableHeader('Hello World');
     // strip any newlines!
     table = table.replace(/\r\n|\n|\r/gm, '');
@@ -165,7 +174,7 @@ describe('emailLayout', function() {
     expect(table).to.endsWith('>Hello World</th></tr>');
   });
 
-  it('should render table rows', function() {
+  it('should render table rows', function () {
     let table = emailLayout.tableRow('Hello', 'World');
     // strip any newlines!
     table = table.replace(/\r\n|\n|\r/gm, '');
@@ -174,7 +183,7 @@ describe('emailLayout', function() {
     expect(table).to.endsWith('>World</td></tr>');
   });
 
-  it('should reformat html5 dates', function() {
+  it('should reformat html5 dates', function () {
     const dateStr = emailLayout.dateFormat(timezoneAdjust('1972-04-29T00:00:00.000Z'));
     expect(dateStr).to.equal('04/29/1972');
     // No requirement on numeric values!
@@ -182,7 +191,7 @@ describe('emailLayout', function() {
     expect(invalidDateStr).to.equal('aaaa-bb-cc');
   });
 
-  it('should join multiple stings with spaces', function() {
+  it('should join multiple stings with spaces', function () {
     const nameStr = emailLayout.joinBySpace('James', 'Earl', 'Jones');
     expect(nameStr).to.equal('James Earl Jones');
     // With crazy extra whitespace!
@@ -190,7 +199,7 @@ describe('emailLayout', function() {
     expect(altName).to.equal('James Jones');
   });
 
-  it('should format general data', function() {
+  it('should format general data', function () {
     let result = emailLayout.general(sampleRequestData.descriptionTimeframe);
     result = scrubAttribs(result); // <--- magic
     expect(result).to.equal(`<tr><th>Request Description</th></tr>
@@ -206,7 +215,7 @@ describe('emailLayout', function() {
 <tr><td>Corr-654321</td></tr>`);
   });
 
-  it('should format general data, without personal numbers', function() {
+  it('should format general data, without personal numbers', function () {
     delete sampleRequestData.descriptionTimeframe[
       'publicServiceEmployeeNumber'
     ];
@@ -223,7 +232,7 @@ describe('emailLayout', function() {
 <tr><td>03/28/2019</td></tr>`);
   });
 
-  it('should format ministry data, with a defaultMinistry', function() {
+  it('should format ministry data, with a defaultMinistry', function () {
     let result = emailLayout.ministry(sampleRequestData.ministry);
     result = scrubAttribs(result);
     expect(result).to.equal(`<tr><th>Ministry or Agency</th></tr>
@@ -231,7 +240,7 @@ describe('emailLayout', function() {
 <tr><td>Children and Family Development</td></tr>`);
   });
 
-  it('should format ministry data, with a multi-ministry selection', function() {
+  it('should format ministry data, with a multi-ministry selection', function () {
     sampleRequestData.ministry.selectedMinistry = [
       { code: 'GCPE', name: 'Government Communications and Public Engagement' },
       { code: 'HLTH', name: 'Health' },
@@ -251,7 +260,7 @@ Labour<br>
 Social Development and Poverty Reduction</td></tr>`);
   });
 
-  it('should format personal data', function() {
+  it('should format personal data', function () {
     let result = emailLayout.personal(sampleRequestData.contactInfo);
     result = scrubAttribs(result);
     expect(result).to.equal(`<tr><th>Contact Information</th></tr>
@@ -265,7 +274,57 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>02/28/2019</td></tr>`);
   });
 
-  it('should format personal data, without aka, middle or business names', function() {
+  it('should format law firm legal proceeding details when involved in a proceeding', function () {
+    sampleRequestData.contactInfo.isLawFirm = true;
+    sampleRequestData.contactInfo.isInvolvedInLegalProceeding = true;
+    sampleRequestData.contactInfo.courtOrTribunal = 'Supreme Court of British Columbia';
+    sampleRequestData.contactInfo.courtOrTribunalFileNumber = 'S12345';
+    sampleRequestData.contactInfo.legalProceedingType = 'Court proceedings';
+
+    sampleRequestData.legalProceedingDetails = {
+      isRequestRelatedToProceeding: true,
+      isPartyToProceeding: false
+    };
+
+    let result = emailLayout.lawFirmLegalDetails(
+      sampleRequestData.contactInfo,
+      sampleRequestData.legalProceedingDetails
+    );
+
+    result = scrubAttribs(result);
+
+    expect(result).to.contain('<tr><th>Law Firm Legal Proceeding Details</th></tr>');
+    expect(result).to.contain('<tr><td>Are you a law firm?</td></tr>');
+    expect(result).to.contain('<tr><td>Yes</td></tr>');
+    expect(result).to.contain('<tr><td>Court or tribunal</td></tr>');
+    expect(result).to.contain('<tr><td>Supreme Court of British Columbia</td></tr>');
+    expect(result).to.contain('<tr><td>Court or tribunal file number</td></tr>');
+    expect(result).to.contain('<tr><td>S12345</td></tr>');
+    expect(result).to.contain('<tr><td>Type of legal proceeding</td></tr>');
+    expect(result).to.contain('<tr><td>Court proceedings</td></tr>');
+    expect(result).to.contain('<tr><td>Is your request for records related to the proceeding involving the B.C. Government?</td></tr>');
+    expect(result).to.contain('<tr><td>Are you a party to the proceeding involving the B.C. Government?</td></tr>');
+  });
+
+  it('should format law firm certification details when not involved in a proceeding', function () {
+    sampleRequestData.contactInfo.isLawFirm = true;
+    sampleRequestData.contactInfo.isInvolvedInLegalProceeding = false;
+    sampleRequestData.contactInfo.legalProceedingCertificationName = 'Colin Westfall';
+
+    let result = emailLayout.lawFirmLegalDetails(sampleRequestData.contactInfo, {});
+
+    result = scrubAttribs(result);
+
+    expect(result).to.contain('<tr><th>Law Firm Legal Proceeding Details</th></tr>');
+    expect(result).to.contain('<tr><td>Are you involved in a legal proceeding with the B.C. Government?</td></tr>');
+    expect(result).to.contain('<tr><td>No</td></tr>');
+    expect(result).to.contain('<tr><td>Section 3(5)(e) FOIPPA Statement</td></tr>');
+    expect(result).to.contain('<tr><td>Certification</td></tr>');
+    expect(result).to.contain('<tr><td>Certified by</td></tr>');
+    expect(result).to.contain('<tr><td>Colin Westfall</td></tr>');
+  });
+
+  it('should format personal data, without aka, middle or business names', function () {
     delete sampleRequestData.contactInfo['alsoKnownAs'];
     delete sampleRequestData.contactInfo['middleName'];
     delete sampleRequestData.contactInfo['businessName'];
@@ -279,7 +338,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>02/28/2019</td></tr>`);
   });
 
-  it('should format another persons data', function() {
+  it('should format another persons data', function () {
     let result = emailLayout.anotherInformation(
       sampleRequestData.anotherInformation
     );
@@ -294,7 +353,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>09/22/2010</td></tr>`);
   });
 
-  it('should format another persons data, without DoB and aka', function() {
+  it('should format another persons data, without DoB and aka', function () {
     delete sampleRequestData.anotherInformation['alsoKnownAs'];
     delete sampleRequestData.anotherInformation['dateOfBirth'];
     delete sampleRequestData.anotherInformation['lastName'];
@@ -309,7 +368,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Colin Jack</td></tr>`);
   });
 
-  it('should format adoptive parent data', function() {
+  it('should format adoptive parent data', function () {
     let result = emailLayout.adoptiveParents(sampleRequestData.adoptiveParents);
     result = scrubAttribs(result);
     expect(result).to.equal(`<tr><th>Adoptive Parents</th></tr>
@@ -319,7 +378,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Homer Westfall</td></tr>`);
   });
 
-  it('should format adoptive parent data, without mother', function() {
+  it('should format adoptive parent data, without mother', function () {
     delete sampleRequestData.adoptiveParents['motherFirstName'];
     delete sampleRequestData.adoptiveParents['motherLastName'];
 
@@ -332,7 +391,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Homer Westfall</td></tr>`);
   });
 
-  it('should format child data', function() {
+  it('should format child data', function () {
     let result = emailLayout.childInformation(
       sampleRequestData.childInformation
     );
@@ -346,7 +405,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>05/26/2007</td></tr>`);
   });
 
-  it('should format child data, without middle name, aka or DoB', function() {
+  it('should format child data, without middle name, aka or DoB', function () {
     delete sampleRequestData.childInformation['alsoKnownAs'];
     delete sampleRequestData.childInformation['dateOfBirth'];
     delete sampleRequestData.childInformation['middleName'];
@@ -360,7 +419,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Johnny Driscol</td></tr>`);
   });
 
-  it('should format Contact Info Options data', function() {
+  it('should format Contact Info Options data', function () {
     let result = emailLayout.contact(sampleRequestData.contactInfoOptions);
     result = scrubAttribs(result);
     expect(result).to.equal(`<tr><td>Phone (primary)</td></tr>
@@ -381,7 +440,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Canada</td></tr>`);
   });
 
-  it('should format minimal Contact Info Options data', function() {
+  it('should format minimal Contact Info Options data', function () {
     let result = emailLayout.contact({
       phonePrimary: '(778) 555-0628'
     });
@@ -390,7 +449,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>(778) 555-0628</td></tr>`);
   });
 
-  it('should format Select About data (myself-child-another)', function() {
+  it('should format Select About data (myself-child-another)', function () {
     let result = emailLayout.about({
       yourself: true,
       child: true,
@@ -401,7 +460,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Myself and A child under 12 and Another person</td></tr>`);
   });
 
-  it('should format Select About data (myself-another)', function() {
+  it('should format Select About data (myself-another)', function () {
     let result = emailLayout.about({
       yourself: true,
       child: false,
@@ -412,7 +471,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Myself and Another person</td></tr>`);
   });
 
-  it('should format Select About data (myself only)', function() {
+  it('should format Select About data (myself only)', function () {
     let result = emailLayout.about({
       yourself: true,
       child: false,
@@ -423,7 +482,7 @@ Social Development and Poverty Reduction</td></tr>`);
 <tr><td>Myself</td></tr>`);
   });
 
-  it('should render a whole email, excluding child and another', function() {
+  it('should render a whole email, excluding child and another', function () {
     sinon.spy(emailLayout, 'general');
     sinon.spy(emailLayout, 'ministry');
     sinon.spy(emailLayout, 'personal');
@@ -431,6 +490,7 @@ Social Development and Poverty Reduction</td></tr>`);
     sinon.spy(emailLayout, 'childInformation');
     sinon.spy(emailLayout, 'contact');
     sinon.spy(emailLayout, 'about');
+    sinon.spy(emailLayout, 'lawFirmLegalDetails');
 
     const data = { requestData: sampleRequestData };
     emailLayout.renderEmail(data);
@@ -450,6 +510,11 @@ Social Development and Poverty Reduction</td></tr>`);
       sampleRequestData.contactInfo
     );
 
+    expect(emailLayout.lawFirmLegalDetails.calledOnce).to.be.true;
+    expect(emailLayout.lawFirmLegalDetails.getCall(0).args[0]).to.equal(
+      sampleRequestData.contactInfo
+    );
+
     // These were not called yet!
     expect(emailLayout.anotherInformation.calledOnce).to.be.false;
     expect(emailLayout.childInformation.calledOnce).to.be.false;
@@ -465,7 +530,7 @@ Social Development and Poverty Reduction</td></tr>`);
     );
   });
 
-  it('should render a whole email, including child and another', function() {
+  it('should render a whole email, including child and another', function () {
     sinon.spy(emailLayout, 'anotherInformation');
     sinon.spy(emailLayout, 'childInformation');
 

--- a/web/src/app/app-routing.module.ts
+++ b/web/src/app/app-routing.module.ts
@@ -28,6 +28,7 @@ import { YouthInCareParent } from './route-components/youthincare-parent/youthin
 import { YouthInCareChild } from './route-components/youthincare-child/youthincare-child.component';
 import { FosterParent } from './route-components/foster-parent/foster-parent.component';
 import { Adoption } from './route-components/adoption/adoption.component';
+import { LegalProceedingDetailsComponent } from './route-components/legal-proceeding-details/legal-proceeding-details.component';
 const routes: Routes = [
   { path: '', component: LandingComponent },
   { path: 'getting-started1', component: GettingStarted1Component },
@@ -41,6 +42,7 @@ const routes: Routes = [
   { path: 'general/ministry-confirmation', component: MinistryConfirmationComponent },
   { path: 'general/description-timeframe', component: DescriptionTimeframeComponent },
   { path: 'general/contact-info', component: ContactInfoComponent },
+  { path: 'general/legal-proceeding-details', component: LegalProceedingDetailsComponent },
   { path: 'general/contact-info-options', component: ContactInfoOptionsComponent },
   { path: 'general/review-submit', component: ReviewSubmitComponent },
   { path: 'general/submit-complete', component: ReviewSubmitCompleteComponent},

--- a/web/src/app/route-components/contact-info/contact-info.component.html
+++ b/web/src/app/route-components/contact-info/contact-info.component.html
@@ -7,11 +7,12 @@
   <div class="foi-content">
     <form [formGroup]="foiForm" novalidate (ngSubmit)="doContinue()">
       <p>
-        We may need to get in touch with you to clarify your request, discuss the status of 
+        We may need to get in touch with you to clarify your request, discuss the status of
         your request or arrange payment of any additional processing fees related to your request.
       </p>
 
       <h2>Your name</h2>
+
       <div class="form-group row">
         <div class="col-lg-6">
           <app-foi-valid
@@ -23,6 +24,7 @@
             <input formControlName="firstName" />
           </app-foi-valid>
         </div>
+
         <div class="col-lg-6">
           <app-foi-valid
             [form]="foiForm"
@@ -44,6 +46,7 @@
           </app-foi-valid>
         </div>
       </div>
+
       <div class="form-group row">
         <div class="col-lg-12">
           <app-foi-valid
@@ -54,21 +57,119 @@
             <input formControlName="businessName" />
           </app-foi-valid>
         </div>
+
+        <div class="col-lg-12" *ngIf="generalRequest">
+            <fieldset>
+              <legend>Are you a law firm?<span class="label-required"> *</span></legend>
+
+              <label>
+                <input type="radio" formControlName="isLawFirm" [value]="true" />
+                Yes
+              </label>
+
+              <label>
+                <input type="radio" formControlName="isLawFirm" [value]="false" />
+                No
+              </label>
+            </fieldset>
+        </div>
+
+        <div class="col-lg-12" *ngIf="generalRequest && isLawFirmApplicant">
+            <fieldset>
+              <legend>
+                Are you involved in a legal proceeding with the B.C. Government?<span class="label-required"> *</span>
+              </legend>
+
+              <label>
+                <input type="radio" formControlName="isInvolvedInLegalProceeding" [value]="true" />
+                Yes
+              </label>
+
+              <label>
+                <input type="radio" formControlName="isInvolvedInLegalProceeding" [value]="false" />
+                No
+              </label>
+            </fieldset>
+        </div>
+
+        <div class="col-lg-12" *ngIf="generalRequest && isLawFirmApplicant && isNotInvolvedInLegalProceeding">
+          <p>
+            Section 3(5)(e) of the Freedom of Information and Protection of Privacy Act (FOIPPA) provides that a record
+            will be excluded from Part 2 of FOIPPA, and will not be disclosed through the Freedom of Information
+            process, if the government of B.C. is required by law to produce, list, or identify it to the applicant
+            (or their principal or client) as part of a proceeding.
+          </p>
+
+          <p>
+            Certification: I certify that, to the best of my knowledge, the Government of BC is not required by law to
+            produce, list, or identify the requested records to me (or my client) because of a legal proceeding.
+          </p>
+
+          <app-foi-valid
+            [form]="foiForm"
+            maxLength="Full name is longer than the maximum {requiredLength} characters."
+            required="Full name is a required field."
+          >
+            <label>Full name<span class="label-required"> *</span>:</label>
+            <input formControlName="legalProceedingCertificationName" />
+          </app-foi-valid>
+        </div>
+
+        <div class="col-lg-12" *ngIf="generalRequest && isLawFirmApplicant && isInvolvedInLegalProceeding">
+          <app-foi-valid
+            [form]="foiForm"
+            maxLength="Court or tribunal is longer than the maximum {requiredLength} characters."
+            required="Court or tribunal is a required field."
+          >
+            <label>Court or tribunal<span class="label-required"> *</span>:</label>
+            <input formControlName="courtOrTribunal" />
+          </app-foi-valid>
+
+          <app-foi-valid
+            [form]="foiForm"
+            maxLength="Court or tribunal file number is longer than the maximum {requiredLength} characters."
+          >
+            <label>Court or tribunal file number:</label>
+            <input formControlName="courtOrTribunalFileNumber" />
+          </app-foi-valid>
+
+          <p>
+            For example: Supreme Court of British Columbia file number, tribunal file number, or arbitration reference
+            number.
+          </p>
+
+          <p>
+            A proceeding is any court, administrative tribunal, or formal arbitration process. The FOIPPA Policy &
+            Procedures Manual defines proceedings as “activities governed by rules of court or rules of judicial or
+            quasi-judicial tribunals that can result in a judgement of a court or ruling of a judicial or quasi-judicial
+            tribunal.”
+          </p>
+
+            <label>Type of legal proceeding<span class="label-required"> *</span>:</label>
+            <select formControlName="legalProceedingType">
+              <option [ngValue]="null">Select type of legal proceeding</option>
+              <option value="Court proceedings">
+                Court proceedings (e.g. civil, family, criminal, class actions, judicial reviews)
+              </option>
+              <option value="Administrative tribunal proceedings">Administrative tribunal proceedings</option>
+              <option value="Arbitration proceedings">Arbitration proceedings</option>
+              <option value="Other">Other</option>
+            </select>
+        </div>
+
         <div class="col-lg-12" *ngIf="generalRequest">
           <label>
-            <input 
-              type="checkbox" 
-              value="IGE" 
-              formControlName="IGE"
-            /> I certify that I am a representative of, and authorized to make a request on behalf of, an 
+            <input type="checkbox" value="IGE" formControlName="IGE" />
+            I certify that I am a representative of, and authorized to make a request on behalf of, an
             <a
               href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/96165_07#Schedule1"
-              target="_blank">
-            Indigenous Governing Entity.
-            </a> 
-            An Indigenous Governing Entity is not required to pay application fees.
-            Indigenous governing entity “means an Indigenous entity that exercises governmental functions, 
-            and includes but is not limited to an Indigenous governing body as defined in the Declaration on the Rights of Indigenous Peoples Act.”
+              target="_blank"
+            >
+              Indigenous Governing Entity.
+            </a>
+            An Indigenous Governing Entity is not required to pay application fees. Indigenous governing entity “means
+            an Indigenous entity that exercises governmental functions, and includes but is not limited to an Indigenous
+            governing body as defined in the Declaration on the Rights of Indigenous Peoples Act.”
           </label>
 
           <app-foi-valid
@@ -76,16 +177,11 @@
             maxLength="Indigenous Governing Entity name is longer than the maximum {requiredLength} characters."
             *ngIf="igeNameRequired"
           >
-            <label>Name of Indigenous Governing Entity<span class="label-required" *ngIf="igeNameRequired"> *</span>:</label>
+            <label>
+              Name of Indigenous Governing Entity<span class="label-required" *ngIf="igeNameRequired"> *</span>:
+            </label>
             <input formControlName="igeName" />
           </app-foi-valid>
-        </div>
-
-        <div class="col-lg-12">
-          <div class="alert alert-light" role="alert">
-            <fa-icon icon="info-circle"></fa-icon>
-            If you are a law firm: Please identify whether you are representing this client or representing someone else. Please also include a file # where possible.
-          </div>
         </div>
       </div>
     </form>

--- a/web/src/app/route-components/contact-info/contact-info.component.ts
+++ b/web/src/app/route-components/contact-info/contact-info.component.ts
@@ -8,6 +8,10 @@ const conditionalRequired = (condition) => {
   return condition ? Validators.required : Validators.nullValidator;
 };
 
+const yesNoRequired = (control) => {
+  return control.value === true || control.value === false ? null : { required: true };
+};
+
 @Component({
   templateUrl: "./contact-info.component.html",
   styleUrls: ["./contact-info.component.scss"],
@@ -21,24 +25,35 @@ export class ContactInfoComponent implements OnInit {
   igeNameValidators = [Validators.maxLength(255)];
   igeNameRequired = false;
 
-  constructor(private fb: FormBuilder, private dataService: DataService) {}
+  constructor(private fb: FormBuilder, private dataService: DataService) { }
 
   ngOnInit() {
+    // Load the current values before building conditional validators.
+    this.foiRequest = this.dataService.getCurrentState(this.targetKey);
+    this.generalRequest = this.foiRequest.requestData.requestType.requestType === "general";
+
     this.foiForm = this.fb.group({
       firstName: [null, Validators.compose([Validators.required, Validators.maxLength(255)])],
       middleName: [null, [Validators.maxLength(255)]],
       lastName: [null, Validators.compose([Validators.required, Validators.maxLength(255)])],
       businessName: [null, Validators.maxLength(255)],
       IGE: [null],
-      igeName: [null, this.igeNameRequired],
+      igeName: [null, this.igeNameValidators],
+
+      isLawFirm: [null],
+      isInvolvedInLegalProceeding: [null],
+      legalProceedingCertificationName: [null, Validators.maxLength(255)],
+      courtOrTribunal: [null, Validators.maxLength(255)],
+      courtOrTribunalFileNumber: [null, Validators.maxLength(255)],
+      legalProceedingType: [null],
     });
 
     this.igeNameRequiredSubscription();
+    this.lawFirmRequiredSubscription();
 
-    // Load the current values & populate the FormGroup.
-    this.foiRequest = this.dataService.getCurrentState(this.targetKey);
-    this.generalRequest = this.foiRequest.requestData.requestType.requestType === "general";
     this.foiForm.patchValue(this.foiRequest.requestData[this.targetKey]);
+
+    this.updateLawFirmValidators();
   }
 
   igeNameRequiredSubscription() {
@@ -50,9 +65,98 @@ export class ContactInfoComponent implements OnInit {
     });
   }
 
+  lawFirmRequiredSubscription() {
+    this.foiForm.get("isLawFirm").valueChanges.subscribe((value) => {
+      if (value !== true) {
+        this.foiForm.get("isInvolvedInLegalProceeding").reset(null, { emitEvent: false });
+        this.foiForm.get("legalProceedingCertificationName").reset(null, { emitEvent: false });
+        this.foiForm.get("courtOrTribunal").reset(null, { emitEvent: false });
+        this.foiForm.get("courtOrTribunalFileNumber").reset(null, { emitEvent: false });
+        this.foiForm.get("legalProceedingType").reset(null, { emitEvent: false });
+      }
+
+      this.updateLawFirmValidators();
+    });
+
+    this.foiForm.get("isInvolvedInLegalProceeding").valueChanges.subscribe((value) => {
+      if (value === true) {
+        this.foiForm.get("legalProceedingCertificationName").reset(null, { emitEvent: false });
+      }
+
+      if (value === false) {
+        this.foiForm.get("courtOrTribunal").reset(null, { emitEvent: false });
+        this.foiForm.get("courtOrTribunalFileNumber").reset(null, { emitEvent: false });
+        this.foiForm.get("legalProceedingType").reset(null, { emitEvent: false });
+      }
+
+      this.updateLawFirmValidators();
+    });
+  }
+
+  updateLawFirmValidators() {
+    const isLawFirm = this.foiForm.get("isLawFirm").value;
+    const isInvolvedInLegalProceeding = this.foiForm.get("isInvolvedInLegalProceeding").value;
+
+    this.setValidators("isLawFirm", this.generalRequest, [], true);
+    this.setValidators("isInvolvedInLegalProceeding", this.generalRequest && isLawFirm === true, [], true);
+
+    this.setValidators(
+      "legalProceedingCertificationName",
+      this.generalRequest && isLawFirm === true && isInvolvedInLegalProceeding === false,
+      [Validators.maxLength(255)]
+    );
+
+    this.setValidators(
+      "courtOrTribunal",
+      this.generalRequest && isLawFirm === true && isInvolvedInLegalProceeding === true,
+      [Validators.maxLength(255)]
+    );
+
+    this.setValidators(
+      "legalProceedingType",
+      this.generalRequest && isLawFirm === true && isInvolvedInLegalProceeding === true,
+      []
+    );
+
+    this.setValidators("courtOrTribunalFileNumber", false, [Validators.maxLength(255)]);
+  }
+
+  setValidators(controlName: string, required: boolean, validators: any[], useYesNoRequired: boolean = false) {
+    const control = this.foiForm.get(controlName);
+    const requiredValidator = useYesNoRequired ? yesNoRequired : Validators.required;
+
+    control.setValidators(required ? validators.concat(requiredValidator) : validators);
+    control.updateValueAndValidity({ emitEvent: false });
+  }
+
+  get isLawFirmApplicant(): boolean {
+    return this.foiForm?.get("isLawFirm")?.value === true;
+  }
+
+  get isNotLawFirmApplicant(): boolean {
+    return this.foiForm?.get("isLawFirm")?.value === false;
+  }
+
+  get isInvolvedInLegalProceeding(): boolean {
+    return this.foiForm?.get("isInvolvedInLegalProceeding")?.value === true;
+  }
+
+  get isNotInvolvedInLegalProceeding(): boolean {
+    return this.foiForm?.get("isInvolvedInLegalProceeding")?.value === false;
+  }
+
   doContinue() {
     // Update save data & proceed.
     this.dataService.setCurrentState(this.foiRequest, this.targetKey, this.foiForm);
+
+    const isLegalProceedingLawFirm =
+      this.foiForm.value.isLawFirm === true && this.foiForm.value.isInvolvedInLegalProceeding === true;
+
+    if (isLegalProceedingLawFirm) {
+      this.base.goFoiForward(this.foiForm.value.IGE ? "legalProceedingNoPaymentPath" : "legalProceedingPaymentPath");
+      return;
+    }
+
     this.base.goFoiForward(this.foiForm.value.IGE ? "noPaymentPath" : "paymentPath");
   }
 

--- a/web/src/app/route-components/legal-proceeding-details/legal-proceeding-details.component.html
+++ b/web/src/app/route-components/legal-proceeding-details/legal-proceeding-details.component.html
@@ -1,0 +1,79 @@
+<foi-base
+  [showInfo]="false"
+  [continueDisabled]="!foiForm.valid"
+  (continue)="doContinue()"
+  (goBack)="doGoBack()"
+>
+  <div class="foi-content">
+    <form [formGroup]="foiForm" novalidate (ngSubmit)="doContinue()">
+      <h2>Legal proceeding details</h2>
+
+      <div class="form-group">
+        <fieldset>
+          <legend>
+            Is your request for records related to the proceeding involving the B.C. Government?<span
+              class="label-required"
+            >
+              *</span
+            >
+          </legend>
+
+          <label>
+            <input type="radio" formControlName="isRequestRelatedToProceeding" [value]="true" />
+            Yes
+          </label>
+
+          <label>
+            <input type="radio" formControlName="isRequestRelatedToProceeding" [value]="false" />
+            No
+          </label>
+        </fieldset>
+      </div>
+
+      <div class="form-group" *ngIf="isRequestRelatedToProceeding">
+        <fieldset>
+          <legend>
+            Are you a party to the proceeding involving the B.C. Government?<span class="label-required"> *</span>
+          </legend>
+
+          <label>
+            <input type="radio" formControlName="isPartyToProceeding" [value]="true" />
+            Yes
+          </label>
+
+          <label>
+            <input type="radio" formControlName="isPartyToProceeding" [value]="false" />
+            No
+          </label>
+        </fieldset>
+
+        <h3>Parties to a proceeding</h3>
+        <p>
+          A party to a legal proceeding is any person who is directly involved in it. This includes people who have
+          started a proceeding (plaintiffs or applicants) and people responding to notice of a proceeding (defendants,
+          respondents, or accused persons).
+        </p>
+      </div>
+    </form>
+  </div>
+
+  <div class="sidebar">
+    <h2>More information</h2>
+
+    <h3>What is a legal proceeding?</h3>
+    <p>
+      A legal proceeding is a formal process used to resolve a dispute or legal matter. This can include:
+    </p>
+
+    <ul>
+      <li>Court proceedings, such as civil, criminal, or family matters before a court</li>
+      <li>Tribunal proceedings, such as hearings before an administrative tribunal</li>
+      <li>Arbitration proceedings, where a dispute is resolved by an arbitrator instead of a court</li>
+    </ul>
+
+    <p>
+      If your request is related to records you are entitled to access through an active or ongoing court, tribunal, or
+      arbitration proceeding, those records cannot be accessed through the Freedom of Information process.
+    </p>
+  </div>
+</foi-base>

--- a/web/src/app/route-components/legal-proceeding-details/legal-proceeding-details.component.ts
+++ b/web/src/app/route-components/legal-proceeding-details/legal-proceeding-details.component.ts
@@ -1,0 +1,74 @@
+import { Component, OnInit, ViewChild } from "@angular/core";
+import { FormBuilder, Validators } from "@angular/forms";
+import { BaseComponent } from "src/app/utils-components/base/base.component";
+import { FoiRequest } from "src/app/models/FoiRequest";
+import { DataService } from "src/app/services/data.service";
+
+const yesNoRequired = (control) => {
+  return control.value === true || control.value === false ? null : { required: true };
+};
+
+@Component({
+  templateUrl: "./legal-proceeding-details.component.html",
+  styleUrls: ["./legal-proceeding-details.component.scss"],
+})
+export class LegalProceedingDetailsComponent implements OnInit {
+  @ViewChild(BaseComponent, { static: true }) base: BaseComponent;
+
+  foiForm = null;
+  foiRequest: FoiRequest;
+  targetKey: string = "legalProceedingDetails";
+
+  constructor(private fb: FormBuilder, private dataService: DataService) {}
+
+  ngOnInit() {
+    this.foiRequest = this.dataService.getCurrentState(this.targetKey);
+
+    this.foiForm = this.fb.group({
+      isRequestRelatedToProceeding: [null, yesNoRequired],
+      isPartyToProceeding: [null],
+    });
+
+    this.foiForm.get("isRequestRelatedToProceeding").valueChanges.subscribe((value) => {
+      const isPartyToProceeding = this.foiForm.get("isPartyToProceeding");
+
+      if (value === true) {
+        isPartyToProceeding.setValidators(yesNoRequired);
+      } else {
+        isPartyToProceeding.reset(null, { emitEvent: false });
+        isPartyToProceeding.clearValidators();
+      }
+
+      isPartyToProceeding.updateValueAndValidity({ emitEvent: false });
+    });
+
+    this.foiForm.patchValue(this.foiRequest.requestData[this.targetKey]);
+    this.updatePartyToProceedingValidators();
+  }
+
+  updatePartyToProceedingValidators() {
+    const isRequestRelatedToProceeding = this.foiForm.get("isRequestRelatedToProceeding").value;
+    const isPartyToProceeding = this.foiForm.get("isPartyToProceeding");
+
+    if (isRequestRelatedToProceeding === true) {
+      isPartyToProceeding.setValidators(yesNoRequired);
+    } else {
+      isPartyToProceeding.clearValidators();
+    }
+
+    isPartyToProceeding.updateValueAndValidity({ emitEvent: false });
+  }
+
+  get isRequestRelatedToProceeding(): boolean {
+    return this.foiForm?.get("isRequestRelatedToProceeding")?.value === true;
+  }
+
+  doContinue() {
+    this.dataService.setCurrentState(this.foiRequest, this.targetKey, this.foiForm);
+    this.base.goFoiForward();
+  }
+
+  doGoBack() {
+    this.base.goFoiBack();
+  }
+}

--- a/web/src/app/route-components/route-components.module.ts
+++ b/web/src/app/route-components/route-components.module.ts
@@ -36,6 +36,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { PaymentComponent } from "./payment/payment.component";
 import { PaymentCompleteComponent } from "./payment-complete/payment-complete.component";
+import { LegalProceedingDetailsComponent } from "./legal-proceeding-details/legal-proceeding-details.component";
 
 // Add an icon to the library for convenient access in other components
 library.add(faSpinner);
@@ -55,6 +56,7 @@ library.add(faSpinner);
     MinistryConfirmationComponent,
     DescriptionTimeframeComponent,
     ContactInfoComponent,
+    LegalProceedingDetailsComponent,
     ReviewSubmitComponent,
     SelectAboutComponent,
     RequestTopicComponent,

--- a/web/src/app/services/data.json
+++ b/web/src/app/services/data.json
@@ -1,39 +1,176 @@
 {
   "referenceData": {
     "ministries": [
-      { "code": "PSE","key": "PSE", "name": "Post-Secondary Education and Future Skills", "publicBody": "Post-Secondary Education and Future Skills" },
-      { "code": "AGR","key": "AGR", "name": "Agriculture and Food", "publicBody": "Agriculture and Food" },
-      { "code": "AG","key": "AG", "name": "Attorney General", "publicBody": "Attorney General" },
-      { "code": "PSA","key": "PSA", "name": "BC Public Service Agency", "publicBody": "Finance" },
-      { "code": "MCF","key": "MCF", "name": "Children and Family Development", "publicBody": "Children and Family Development" },
-      { "code": "CITZ","key": "CITZ", "name": "Citizens’ Services", "publicBody": "Citizens’ Services" },
-      { "code": "ECC","key": "ECC", "name": "Education and Child Care", "publicBody": "Education and Child Care" },
-      { "code": "ECS","key": "ECS", "name": "Energy and Climate Solutions", "publicBody": "Energy and Climate Solutions" },
-      { "code": "ENV","key": "MOE", "name": "Environment and Parks", "publicBody": "Environment and Parks" },
-      { "code": "EAO","key": "EAO", "name": "Environmental Assessment Office", "publicBody": "Environment and Parks" },
-      { "code": "FIN", "key": "FIN","name": "Finance", "publicBody":"Finance" },
-      { "code": "FOR","key": "FOR", "name": "Forests", "publicBody": "Forests" },
-      { "code": "GCP","key": "GCP", "name": "Government Communications and Public Engagement", "publicBody": "Finance" },
-      { "code": "HTH","key": "HTH", "name": "Health", "publicBody": "Health" },
-      { "code": "IRR","key": "IRR", "name": "Indigenous Relations and Reconciliation", "publicBody": "Indigenous Relations and Reconciliation" },
-      { "code": "DAS","key": "DAS", "name": "Declaration Act Secretariat", "publicBody": "Indigenous Relations and Reconciliation" },
-      { "code": "JED","key": "JED", "name": "Jobs and Economic Growth", "publicBody": "Jobs and Economic Growth" },
-      { "code": "LBR","key": "LBR","name": "Labour", "publicBody": "Labour" },
-      { "code": "WLR", "key": "WLR","name": "Water, Land and Resource Stewardship", "publicBody": "Water, Land and Resource Stewardship" },
-      { "code": "HSG","key": "HSG", "name": "Housing and Municipal Affairs", "publicBody": "Housing and Municipal Affairs" },
-      { "code": "OOP","key": "OOP","name": "Office of the Premier", "publicBody": "Office of the Premier" },
-      { "code": "PSSG","key": "PSSG", "name": "Public Safety and Solicitor General", "publicBody": "Public Safety and Solicitor General" },
-      { "code": "MSD","key": "MSD", "name": "Social Development and Poverty Reduction", "publicBody": "Social Development and Poverty Reduction" },
-      { "code": "TACS","key": "TACS", "name": "Tourism, Arts, Culture and Sport", "publicBody": "Tourism, Arts, Culture and Sport" },
-      { "code": "TRAN","key": "TRAN", "name": "Transportation and Transit", "publicBody": "Transportation and Transit" },
-      { "code": "EMC","key": "EMC", "name": "Emergency Management and Climate Readiness", "publicBody": "Emergency Management and Climate Readiness" },
-      { "code": "INF","key": "INF", "name": "Infrastructure", "publicBody": "Infrastructure" },
-      { "code": "MCM","key": "MCM", "name": "Mining and Critical Minerals", "publicBody": "Mining and Critical Minerals" }
-
+      {
+        "code": "PSE",
+        "key": "PSE",
+        "name": "Post-Secondary Education and Future Skills",
+        "publicBody": "Post-Secondary Education and Future Skills"
+      },
+      {
+        "code": "AGR",
+        "key": "AGR",
+        "name": "Agriculture and Food",
+        "publicBody": "Agriculture and Food"
+      },
+      {
+        "code": "AG",
+        "key": "AG",
+        "name": "Attorney General",
+        "publicBody": "Attorney General"
+      },
+      {
+        "code": "PSA",
+        "key": "PSA",
+        "name": "BC Public Service Agency",
+        "publicBody": "Finance"
+      },
+      {
+        "code": "MCF",
+        "key": "MCF",
+        "name": "Children and Family Development",
+        "publicBody": "Children and Family Development"
+      },
+      {
+        "code": "CITZ",
+        "key": "CITZ",
+        "name": "Citizens’ Services",
+        "publicBody": "Citizens’ Services"
+      },
+      {
+        "code": "ECC",
+        "key": "ECC",
+        "name": "Education and Child Care",
+        "publicBody": "Education and Child Care"
+      },
+      {
+        "code": "ECS",
+        "key": "ECS",
+        "name": "Energy and Climate Solutions",
+        "publicBody": "Energy and Climate Solutions"
+      },
+      {
+        "code": "ENV",
+        "key": "MOE",
+        "name": "Environment and Parks",
+        "publicBody": "Environment and Parks"
+      },
+      {
+        "code": "EAO",
+        "key": "EAO",
+        "name": "Environmental Assessment Office",
+        "publicBody": "Environment and Parks"
+      },
+      {
+        "code": "FIN",
+        "key": "FIN",
+        "name": "Finance",
+        "publicBody": "Finance"
+      },
+      {
+        "code": "FOR",
+        "key": "FOR",
+        "name": "Forests",
+        "publicBody": "Forests"
+      },
+      {
+        "code": "GCP",
+        "key": "GCP",
+        "name": "Government Communications and Public Engagement",
+        "publicBody": "Finance"
+      },
+      {
+        "code": "HTH",
+        "key": "HTH",
+        "name": "Health",
+        "publicBody": "Health"
+      },
+      {
+        "code": "IRR",
+        "key": "IRR",
+        "name": "Indigenous Relations and Reconciliation",
+        "publicBody": "Indigenous Relations and Reconciliation"
+      },
+      {
+        "code": "DAS",
+        "key": "DAS",
+        "name": "Declaration Act Secretariat",
+        "publicBody": "Indigenous Relations and Reconciliation"
+      },
+      {
+        "code": "JED",
+        "key": "JED",
+        "name": "Jobs and Economic Growth",
+        "publicBody": "Jobs and Economic Growth"
+      },
+      {
+        "code": "LBR",
+        "key": "LBR",
+        "name": "Labour",
+        "publicBody": "Labour"
+      },
+      {
+        "code": "WLR",
+        "key": "WLR",
+        "name": "Water, Land and Resource Stewardship",
+        "publicBody": "Water, Land and Resource Stewardship"
+      },
+      {
+        "code": "HSG",
+        "key": "HSG",
+        "name": "Housing and Municipal Affairs",
+        "publicBody": "Housing and Municipal Affairs"
+      },
+      {
+        "code": "OOP",
+        "key": "OOP",
+        "name": "Office of the Premier",
+        "publicBody": "Office of the Premier"
+      },
+      {
+        "code": "PSSG",
+        "key": "PSSG",
+        "name": "Public Safety and Solicitor General",
+        "publicBody": "Public Safety and Solicitor General"
+      },
+      {
+        "code": "MSD",
+        "key": "MSD",
+        "name": "Social Development and Poverty Reduction",
+        "publicBody": "Social Development and Poverty Reduction"
+      },
+      {
+        "code": "TACS",
+        "key": "TACS",
+        "name": "Tourism, Arts, Culture and Sport",
+        "publicBody": "Tourism, Arts, Culture and Sport"
+      },
+      {
+        "code": "TRAN",
+        "key": "TRAN",
+        "name": "Transportation and Transit",
+        "publicBody": "Transportation and Transit"
+      },
+      {
+        "code": "EMC",
+        "key": "EMC",
+        "name": "Emergency Management and Climate Readiness",
+        "publicBody": "Emergency Management and Climate Readiness"
+      },
+      {
+        "code": "INF",
+        "key": "INF",
+        "name": "Infrastructure",
+        "publicBody": "Infrastructure"
+      },
+      {
+        "code": "MCM",
+        "key": "MCM",
+        "name": "Mining and Critical Minerals",
+        "publicBody": "Mining and Critical Minerals"
+      }
     ],
     "topicYourself": [
-   
-      
       {
         "value": "publicServiceEmployment",
         "text": "Your employment with the public service",
@@ -49,20 +186,74 @@
         "text": "Your income assistance history",
         "ministryCode": "MSD"
       },
-      { "value": "childprotectionparent", "text": "Your records as a <strong>parent</strong> from a child protection investigation", "ministryCode": "MCF","hassubscreen":"true" },
-      { "value": "childprotectionchild", "text": "Your records as a <strong>child</strong> from a child protection investigation", "ministryCode": "MCF" ,"hassubscreen":"true" },
-      { "value": "youthincareparent", "text": "Your records as a <strong>parent</strong> of a child/youth in care or receiving services", "ministryCode": "MCF" ,"hassubscreen":"true" },
-      { "value": "youthincarechild", "text": "Your records as a <strong>child/youth</strong> in care or receiving services", "ministryCode": "MCF" ,"hassubscreen":"true" },
-      { "value": "fosterparent", "text": "Your records as a foster parent", "ministryCode": "MCF" ,"hassubscreen":"true"},
-      { "value": "adoption", "text": "Your records from an adoption", "ministryCode": "MCF" ,"hassubscreen":"true" },
-      { "value": "anotherTopic", "text": "Other", "ministryCode": null }
+      {
+        "value": "childprotectionparent",
+        "text": "Your records as a <strong>parent</strong> from a child protection investigation",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "childprotectionchild",
+        "text": "Your records as a <strong>child</strong> from a child protection investigation",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "youthincareparent",
+        "text": "Your records as a <strong>parent</strong> of a child/youth in care or receiving services",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "youthincarechild",
+        "text": "Your records as a <strong>child/youth</strong> in care or receiving services",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "fosterparent",
+        "text": "Your records as a foster parent",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "adoption",
+        "text": "Your records from an adoption",
+        "ministryCode": "MCF",
+        "hassubscreen": "true"
+      },
+      {
+        "value": "anotherTopic",
+        "text": "Other",
+        "ministryCode": null
+      }
     ],
     "topicAnother": [
-      { "value": "childprotectionparent", "text": "Child protection – Parent Submitting Request", "ministryCode": "MCF" },
-      { "value": "childprotectionchild", "text": "Child protection – Child Submitting Request", "ministryCode": "MCF" },
-      { "value": "youthincareparent", "text": "Youth in care - Parent Submitting Request", "ministryCode": "MCF" },
-      { "value": "youthincarechild", "text": "Youth in care - Child Submitting Request", "ministryCode": "MCF" },
-      { "value": "fosterparent", "text": "Foster Parent", "ministryCode": "MCF" },
+      {
+        "value": "childprotectionparent",
+        "text": "Child protection – Parent Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "childprotectionchild",
+        "text": "Child protection – Child Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "youthincareparent",
+        "text": "Youth in care - Parent Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "youthincarechild",
+        "text": "Youth in care - Child Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "fosterparent",
+        "text": "Foster Parent",
+        "ministryCode": "MCF"
+      },
       {
         "value": "publicServiceEmployment",
         "text": "The person's employment with the public service",
@@ -83,15 +274,43 @@
         "text": "Child protection and youth care",
         "ministryCode": "MCF"
       },
-      { "value": "adoption", "text": "Adoption", "ministryCode": "MCF" },
-      { "value": "anotherTopic", "text": "Other", "ministryCode": null }
+      {
+        "value": "adoption",
+        "text": "Adoption",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "anotherTopic",
+        "text": "Other",
+        "ministryCode": null
+      }
     ],
     "topicYourselfAnother": [
-      { "value": "childprotectionparent", "text": "Child protection – Parent Submitting Request", "ministryCode": "MCF" },
-      { "value": "childprotectionchild", "text": "Child protection – Child Submitting Request", "ministryCode": "MCF" },
-      { "value": "youthincareparent", "text": "Youth in care - Parent Submitting Request", "ministryCode": "MCF" },
-      { "value": "youthincarechild", "text": "Youth in care - Child Submitting Request", "ministryCode": "MCF" },
-      { "value": "fosterparent", "text": "Foster Parent", "ministryCode": "MCF" },
+      {
+        "value": "childprotectionparent",
+        "text": "Child protection – Parent Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "childprotectionchild",
+        "text": "Child protection – Child Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "youthincareparent",
+        "text": "Youth in care - Parent Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "youthincarechild",
+        "text": "Youth in care - Child Submitting Request",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "fosterparent",
+        "text": "Foster Parent",
+        "ministryCode": "MCF"
+      },
       {
         "value": "publicServiceEmployment",
         "text": "Employment with the public service",
@@ -112,206 +331,501 @@
         "text": "Child protection and youth care",
         "ministryCode": "MCF"
       },
-      { "value": "adoption", "text": "Adoption", "ministryCode": "MCF" },
-      { "value": "anotherTopic", "text": "Other", "ministryCode": null }
+      {
+        "value": "adoption",
+        "text": "Adoption",
+        "ministryCode": "MCF"
+      },
+      {
+        "value": "anotherTopic",
+        "text": "Other",
+        "ministryCode": null
+      }
     ],
-    "youthincarechild":[
-      { "mainoption":"Child in Care Records" , "suboptions":[
-        {"option":"Personal History, Recordings & Service Plans", "description":"Contains file recordings, personal history and personal identification information"},
-        {"option":"Cultural Planning / Roots"},
-        {"option":"Legal & Agreements", "description":"Contains court order in-care records, and relevant legal and agreement related correspondence"},
-        {"option":"Financial Documentation", "description":"Contains records and correspondence relating to the financial support services provided to a family"},
-        {"option":"External Assessment & Reports", "description":"Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"},
-        {"option":"Medical", "description":"Contains records relating to the medical history of the family"},
-        {"option":"Internal Assessments", "description":"Contains records relating to assessment strengths and risk"},
-        {"option":"Reviews", "description":"Contains records relating to case reviews, complaints and related correspondence"},
-        {"option":"Adoption", "description":"Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"},
-        {"option":"Out of Care Services", "description":"Contains records related to children that are in out of care arrangement"},
-        {"option":"General Correspondence", "description":"Contains correspondence and records of a general nature not found elsewhere in the file"},
-        {"option":"Collaborative Planning & Decisions Making", "description":"Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"},
-        {"option":"Education, Employment & Training"},
-        {"option":"Case Notes", "description":"Contains practitioner (social worker) case notes"}
-        
-        ] },
-        {
-          "mainoption":"Child and Youth Mental Health Records" ,"suboptions":[
-            {"option":"Clinical History"},
-            {"option":"Complex Care Intervention"},
-            {"option":"Assessment & Reports"},
-            {"option":"Psychological Test Protocols & Rough Notes"},
-            {"option":"Clinician’s Standardized Questionnaires & Rough Notes"},
-            {"option":"Artwork & Photos"},
-            {"option":"Child & Youth Mental Health Case Files "},
-            {"option":"Case Notes"}
-          ]
-        },
-        {
-          "mainoption":"Child and Youth Special Needs Records" ,"suboptions":[
-            {"option":"Personal History & Recording"},
-            {"option":"Intake / Service Request & Memo"},
-            {"option":"Legal and Financial Documentation "},
-            {"option":"Reports"},
-            {"option":"Correspondence"},
-            {"option":"At Home Program Legal & Financial"},
-            {"option":"Autism Funding"},
-            {"option":"Respite Benefits"},
-            {"option":"Case Notes"}
-          ]
-        },
-        {
-          "mainoption":"Youth Agreement" ,"suboptions":[
-            {"option":"Personal History & Recordings"},
-            {"option":"Service Request & Memo"},
-            {"option":"Agreements"},
-            {"option":"Reports"},
-            {"option":"Financial Documentation"},
-            {"option":"Program Planning Documentation"},
-            {"option":"Case Notes"}         
-          ]
-        },
-        
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
+    "youthincarechild": [
+      {
+        "mainoption": "Child in Care Records",
+        "suboptions": [
+          {
+            "option": "Personal History, Recordings & Service Plans",
+            "description": "Contains file recordings, personal history and personal identification information"
+          },
+          {
+            "option": "Cultural Planning / Roots"
+          },
+          {
+            "option": "Legal & Agreements",
+            "description": "Contains court order in-care records, and relevant legal and agreement related correspondence"
+          },
+          {
+            "option": "Financial Documentation",
+            "description": "Contains records and correspondence relating to the financial support services provided to a family"
+          },
+          {
+            "option": "External Assessment & Reports",
+            "description": "Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"
+          },
+          {
+            "option": "Medical",
+            "description": "Contains records relating to the medical history of the family"
+          },
+          {
+            "option": "Internal Assessments",
+            "description": "Contains records relating to assessment strengths and risk"
+          },
+          {
+            "option": "Reviews",
+            "description": "Contains records relating to case reviews, complaints and related correspondence"
+          },
+          {
+            "option": "Adoption",
+            "description": "Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"
+          },
+          {
+            "option": "Out of Care Services",
+            "description": "Contains records related to children that are in out of care arrangement"
+          },
+          {
+            "option": "General Correspondence",
+            "description": "Contains correspondence and records of a general nature not found elsewhere in the file"
+          },
+          {
+            "option": "Collaborative Planning & Decisions Making",
+            "description": "Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"
+          },
+          {
+            "option": "Education, Employment & Training"
+          },
+          {
+            "option": "Case Notes",
+            "description": "Contains practitioner (social worker) case notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Child and Youth Mental Health Records",
+        "suboptions": [
+          {
+            "option": "Clinical History"
+          },
+          {
+            "option": "Complex Care Intervention"
+          },
+          {
+            "option": "Assessment & Reports"
+          },
+          {
+            "option": "Psychological Test Protocols & Rough Notes"
+          },
+          {
+            "option": "Clinician’s Standardized Questionnaires & Rough Notes"
+          },
+          {
+            "option": "Artwork & Photos"
+          },
+          {
+            "option": "Child & Youth Mental Health Case Files "
+          },
+          {
+            "option": "Case Notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Child and Youth Special Needs Records",
+        "suboptions": [
+          {
+            "option": "Personal History & Recording"
+          },
+          {
+            "option": "Intake / Service Request & Memo"
+          },
+          {
+            "option": "Legal and Financial Documentation "
+          },
+          {
+            "option": "Reports"
+          },
+          {
+            "option": "Correspondence"
+          },
+          {
+            "option": "At Home Program Legal & Financial"
+          },
+          {
+            "option": "Autism Funding"
+          },
+          {
+            "option": "Respite Benefits"
+          },
+          {
+            "option": "Case Notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Youth Agreement",
+        "suboptions": [
+          {
+            "option": "Personal History & Recordings"
+          },
+          {
+            "option": "Service Request & Memo"
+          },
+          {
+            "option": "Agreements"
+          },
+          {
+            "option": "Reports"
+          },
+          {
+            "option": "Financial Documentation"
+          },
+          {
+            "option": "Program Planning Documentation"
+          },
+          {
+            "option": "Case Notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "childprotectionparent":[
-      { "mainoption":"Child Protection Investigation Records (Family Service File)" , "suboptions":[
-        {"option":"Personal History and Recording", "description":"Contains file recordings, personal history and personal identification information"},
-        {"option":"Intake & Incident, Service Request & Memo", "description":"Contains records related to child protection investigations, memos, requests for services, and after-hours reports"},
-        {"option":"Legal & Agreements", "description":"Contains court order in-care records, and relevant legal and agreement related correspondence"},
-        {"option":"Financial Documentation", "description":"Contains records and correspondence relating to the financial support services provided to a family"},
-        {"option":"External Assessment & Reports", "description":"Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"},
-        {"option":"Medical", "description":"Contains records relating to the medical history of the family"},
-        {"option":"Internal Assessments & Service Plans", "description":"Contains records relating to assessment strengths and risk"},
-        {"option":"Reviews", "description":"Contains records relating to case reviews, complaints and related correspondence"},
-        {"option":"Adoption", "description":"Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"},
-        {"option":"Out of Care Services", "description":"Contains records related to children that are in out of care arrangement"},
-        {"option":"General Correspondence", "description":"Contains correspondence and records of a general nature not found elsewhere in the file"},
-        {"option":"Collaborative Planning & Decisions Making", "description":"Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"},        
-        {"option":"Case Notes", "description":"Contains practitioner (social worker) case notes"}
-        
-        ] },
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
-
+    "childprotectionparent": [
+      {
+        "mainoption": "Child Protection Investigation Records (Family Service File)",
+        "suboptions": [
+          {
+            "option": "Personal History and Recording",
+            "description": "Contains file recordings, personal history and personal identification information"
+          },
+          {
+            "option": "Intake & Incident, Service Request & Memo",
+            "description": "Contains records related to child protection investigations, memos, requests for services, and after-hours reports"
+          },
+          {
+            "option": "Legal & Agreements",
+            "description": "Contains court order in-care records, and relevant legal and agreement related correspondence"
+          },
+          {
+            "option": "Financial Documentation",
+            "description": "Contains records and correspondence relating to the financial support services provided to a family"
+          },
+          {
+            "option": "External Assessment & Reports",
+            "description": "Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"
+          },
+          {
+            "option": "Medical",
+            "description": "Contains records relating to the medical history of the family"
+          },
+          {
+            "option": "Internal Assessments & Service Plans",
+            "description": "Contains records relating to assessment strengths and risk"
+          },
+          {
+            "option": "Reviews",
+            "description": "Contains records relating to case reviews, complaints and related correspondence"
+          },
+          {
+            "option": "Adoption",
+            "description": "Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"
+          },
+          {
+            "option": "Out of Care Services",
+            "description": "Contains records related to children that are in out of care arrangement"
+          },
+          {
+            "option": "General Correspondence",
+            "description": "Contains correspondence and records of a general nature not found elsewhere in the file"
+          },
+          {
+            "option": "Collaborative Planning & Decisions Making",
+            "description": "Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"
+          },
+          {
+            "option": "Case Notes",
+            "description": "Contains practitioner (social worker) case notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "childprotectionchild":[
-
-      { "mainoption":"Investigation of your parent when you were a child" , "suboptions":[
-        {"option":"Personal History and Recording", "description":"Contains file recordings, personal history and personal identification information"},
-        {"option":"Intake & Incident, Service Request & Memo", "description":"Contains records related to child protection investigations, memos, requests for services, and after-hours reports"},
-        {"option":"Legal & Agreements", "description":"Contains court order in-care records, and relevant legal and agreement related correspondence"},
-        {"option":"Financial Documentation", "description":"Contains records and correspondence relating to the financial support services provided to a family"},
-        {"option":"External Assessment & Reports", "description":"Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"},
-        {"option":"Medical", "description":"Contains records relating to the medical history of the family"},
-        {"option":"Internal Assessments & Service Plans", "description":"Contains records relating to assessment strengths and risk"},
-        {"option":"Reviews", "description":"Contains records relating to case reviews, complaints and related correspondence"},
-        {"option":"Adoption", "description":"Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"},
-        {"option":"Out of Care Services", "description":"Contains records related to children that are in out of care arrangement"},
-        {"option":"General Correspondence", "description":"Contains correspondence and records of a general nature not found elsewhere in the file"},
-        {"option":"Collaborative Planning & Decisions Making", "description":"Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"},        
-        {"option":"Case Notes", "description":"Contains practitioner (social worker) case notes"}
-        
-        ] },
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
-
-
+    "childprotectionchild": [
+      {
+        "mainoption": "Investigation of your parent when you were a child",
+        "suboptions": [
+          {
+            "option": "Personal History and Recording",
+            "description": "Contains file recordings, personal history and personal identification information"
+          },
+          {
+            "option": "Intake & Incident, Service Request & Memo",
+            "description": "Contains records related to child protection investigations, memos, requests for services, and after-hours reports"
+          },
+          {
+            "option": "Legal & Agreements",
+            "description": "Contains court order in-care records, and relevant legal and agreement related correspondence"
+          },
+          {
+            "option": "Financial Documentation",
+            "description": "Contains records and correspondence relating to the financial support services provided to a family"
+          },
+          {
+            "option": "External Assessment & Reports",
+            "description": "Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"
+          },
+          {
+            "option": "Medical",
+            "description": "Contains records relating to the medical history of the family"
+          },
+          {
+            "option": "Internal Assessments & Service Plans",
+            "description": "Contains records relating to assessment strengths and risk"
+          },
+          {
+            "option": "Reviews",
+            "description": "Contains records relating to case reviews, complaints and related correspondence"
+          },
+          {
+            "option": "Adoption",
+            "description": "Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"
+          },
+          {
+            "option": "Out of Care Services",
+            "description": "Contains records related to children that are in out of care arrangement"
+          },
+          {
+            "option": "General Correspondence",
+            "description": "Contains correspondence and records of a general nature not found elsewhere in the file"
+          },
+          {
+            "option": "Collaborative Planning & Decisions Making",
+            "description": "Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"
+          },
+          {
+            "option": "Case Notes",
+            "description": "Contains practitioner (social worker) case notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "youthincareparent":[
-
-      { "mainoption":"Child Protection Investigation Records (Family Service File)" , "suboptions":[
-        {"option":"Personal History and Recording", "description":"Contains file recordings, personal history and personal identification information"},
-        {"option":"Intake & Incident, Service Request & Memo", "description":"Contains records related to child protection investigations, memos, requests for services, and after-hours reports"},
-        {"option":"Legal & Agreements", "description":"Contains court order in-care records, and relevant legal and agreement related correspondence"},
-        {"option":"Financial Documentation", "description":"Contains records and correspondence relating to the financial support services provided to a family"},
-        {"option":"External Assessment & Reports", "description":"Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"},
-        {"option":"Medical", "description":"Contains records relating to the medical history of the family"},
-        {"option":"Internal Assessments & Service Plans", "description":"Contains records relating to assessment strengths and risk"},
-        {"option":"Reviews", "description":"Contains records relating to case reviews, complaints and related correspondence"},
-        {"option":"Adoption", "description":"Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"},
-        {"option":"Out of Care Services", "description":"Contains records related to children that are in out of care arrangement"},
-        {"option":"General Correspondence", "description":"Contains correspondence and records of a general nature not found elsewhere in the file"},
-        {"option":"Collaborative Planning & Decisions Making", "description":"Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"},        
-        {"option":"Case Notes", "description":"Contains practitioner (social worker) case notes"}
-        
-        ] },
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
-
-
-
+    "youthincareparent": [
+      {
+        "mainoption": "Child Protection Investigation Records (Family Service File)",
+        "suboptions": [
+          {
+            "option": "Personal History and Recording",
+            "description": "Contains file recordings, personal history and personal identification information"
+          },
+          {
+            "option": "Intake & Incident, Service Request & Memo",
+            "description": "Contains records related to child protection investigations, memos, requests for services, and after-hours reports"
+          },
+          {
+            "option": "Legal & Agreements",
+            "description": "Contains court order in-care records, and relevant legal and agreement related correspondence"
+          },
+          {
+            "option": "Financial Documentation",
+            "description": "Contains records and correspondence relating to the financial support services provided to a family"
+          },
+          {
+            "option": "External Assessment & Reports",
+            "description": "Contains all reports and assessments obtained from other ministries, agencies and external professionals (e.g., psychologists)"
+          },
+          {
+            "option": "Medical",
+            "description": "Contains records relating to the medical history of the family"
+          },
+          {
+            "option": "Internal Assessments & Service Plans",
+            "description": "Contains records relating to assessment strengths and risk"
+          },
+          {
+            "option": "Reviews",
+            "description": "Contains records relating to case reviews, complaints and related correspondence"
+          },
+          {
+            "option": "Adoption",
+            "description": "Contains records relating to a pending adoption, and when the adoption file is opened the information is copied into an appropriate adoption file - this may be applicable to a child in care placed for adoption"
+          },
+          {
+            "option": "Out of Care Services",
+            "description": "Contains records related to children that are in out of care arrangement"
+          },
+          {
+            "option": "General Correspondence",
+            "description": "Contains correspondence and records of a general nature not found elsewhere in the file"
+          },
+          {
+            "option": "Collaborative Planning & Decisions Making",
+            "description": "Contains legal documentation and correspondence related to a family participating in the Collaborative Planning and Decision-Making programs also known as ADR"
+          },
+          {
+            "option": "Case Notes",
+            "description": "Contains practitioner (social worker) case notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "fosterparent":[
-
-      { "mainoption":"Resource (Foster Parent) File " , "suboptions":[
-        {"option":"Recording"},
-        {"option":"Applications, Assessments, Approvals and Licensing Documentation"},
-        {"option":"Financial"},
-        {"option":"Investigations, Incidents and Reports"},
-        {"option":"Accountability, Training and Recruitment"},
-        {"option":"Relief Caregiver Documentation"},
-        {"option":"Child Information"},
-        {"option":"General Correspondence "},
-        {"option":"Case Notes"}
-        
-        
-        ] },
-        { "mainoption":"Financial Contract File " , "suboptions":[
-          {"option":"Legal (Signed Documents)"},
-          {"option":"Contract Selection and Approval"},
-          {"option":"Accountability"},
-          {"option":"Financial"}                            
-          ] },
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
-
-
-
+    "fosterparent": [
+      {
+        "mainoption": "Resource (Foster Parent) File ",
+        "suboptions": [
+          {
+            "option": "Recording"
+          },
+          {
+            "option": "Applications, Assessments, Approvals and Licensing Documentation"
+          },
+          {
+            "option": "Financial"
+          },
+          {
+            "option": "Investigations, Incidents and Reports"
+          },
+          {
+            "option": "Accountability, Training and Recruitment"
+          },
+          {
+            "option": "Relief Caregiver Documentation"
+          },
+          {
+            "option": "Child Information"
+          },
+          {
+            "option": "General Correspondence "
+          },
+          {
+            "option": "Case Notes"
+          }
+        ]
+      },
+      {
+        "mainoption": "Financial Contract File ",
+        "suboptions": [
+          {
+            "option": "Legal (Signed Documents)"
+          },
+          {
+            "option": "Contract Selection and Approval"
+          },
+          {
+            "option": "Accountability"
+          },
+          {
+            "option": "Financial"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "adoption":[
-
-      { "mainoption":"Are you the biological parent?" , "mainoptionvalue":"Biological Parent", "suboptions":[
-        {"option":"Adoptive Parent(s)’ Background"},
-        {"option":"Child & Birth Family Background"},
-        {"option":"Post Placement Documentation & Correspondence"},
-        {"option":"Financial"},
-        {"option":"Case Notes"},
-        {"option":"Legal and Other Documents"},
-        {"option":"Information and Correspondence"}
-                       
-        ] },
-        { "mainoption":"Are you the adoptive parent?" , "mainoptionvalue":"Adoptive Parent", "suboptions":[
-          {"option":"Adoptive Parent(s)’ Background"},
-          {"option":"Child & Birth Family Background"},
-          {"option":"Post Placement Documentation & Correspondence"},
-          {"option":"Financial"},
-          {"option":"Case Notes"},
-          {"option":"Legal and Other Documents"},
-          {"option":"Information and Correspondence"}
-                         
-          ] },
-          { "mainoption":"Are you the adopted child?" , "mainoptionvalue":"Adoptive Child", "suboptions":[
-            {"option":"Adoptive Parent(s)’ Background"},
-            {"option":"Child & Birth Family Background"},
-            {"option":"Post Placement Documentation & Correspondence"},
-            {"option":"Financial"},
-            {"option":"Case Notes"},
-            {"option":"Legal and Other Documents"},
-            {"option":"Information and Correspondence"}
-                           
-            ] },
-        {
-          "mainoption":"Other" ,"suboptions":[]
-        }
-
-
+    "adoption": [
+      {
+        "mainoption": "Are you the biological parent?",
+        "mainoptionvalue": "Biological Parent",
+        "suboptions": [
+          {
+            "option": "Adoptive Parent(s)’ Background"
+          },
+          {
+            "option": "Child & Birth Family Background"
+          },
+          {
+            "option": "Post Placement Documentation & Correspondence"
+          },
+          {
+            "option": "Financial"
+          },
+          {
+            "option": "Case Notes"
+          },
+          {
+            "option": "Legal and Other Documents"
+          },
+          {
+            "option": "Information and Correspondence"
+          }
+        ]
+      },
+      {
+        "mainoption": "Are you the adoptive parent?",
+        "mainoptionvalue": "Adoptive Parent",
+        "suboptions": [
+          {
+            "option": "Adoptive Parent(s)’ Background"
+          },
+          {
+            "option": "Child & Birth Family Background"
+          },
+          {
+            "option": "Post Placement Documentation & Correspondence"
+          },
+          {
+            "option": "Financial"
+          },
+          {
+            "option": "Case Notes"
+          },
+          {
+            "option": "Legal and Other Documents"
+          },
+          {
+            "option": "Information and Correspondence"
+          }
+        ]
+      },
+      {
+        "mainoption": "Are you the adopted child?",
+        "mainoptionvalue": "Adoptive Child",
+        "suboptions": [
+          {
+            "option": "Adoptive Parent(s)’ Background"
+          },
+          {
+            "option": "Child & Birth Family Background"
+          },
+          {
+            "option": "Post Placement Documentation & Correspondence"
+          },
+          {
+            "option": "Financial"
+          },
+          {
+            "option": "Case Notes"
+          },
+          {
+            "option": "Legal and Other Documents"
+          },
+          {
+            "option": "Information and Correspondence"
+          }
+        ]
+      },
+      {
+        "mainoption": "Other",
+        "suboptions": []
+      }
     ],
-    "delayfactors":[
+    "delayfactors": [
       "childprotectionparent",
       "childprotectionchild",
       "youthincareparent",
@@ -321,17 +835,32 @@
     ]
   },
   "routeTree": [
-    { "route": "", "progress": 0 },
-    { "route": "getting-started1", "progress": 1 },
-    { "route": "getting-started2", "progress": 1 },
+    {
+      "route": "",
+      "progress": 0
+    },
+    {
+      "route": "getting-started1",
+      "progress": 1
+    },
+    {
+      "route": "getting-started2",
+      "progress": 1
+    },
     {
       "route": "getting-started3",
       "progress": 3,
       "choices": {
         "general": {
           "routes": [
-            { "route": "general/fee-info", "progress": 2 },
-            { "route": "general/ministry-confirmation", "progress": 2 },
+            {
+              "route": "general/fee-info",
+              "progress": 2
+            },
+            {
+              "route": "general/ministry-confirmation",
+              "progress": 2
+            },
             {
               "route": "general/description-timeframe",
               "progress": 2
@@ -342,22 +871,92 @@
               "choices": {
                 "paymentPath": {
                   "routes": [
-                    { "route": "general/contact-info-options", "progress": 3 },
-                    { "route": "general/review-submit", "progress": 4 },
-                    { "route": "general/payment", "progress": 4 },
+                    {
+                      "route": "general/contact-info-options",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/review-submit",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/payment",
+                      "progress": 4
+                    },
                     {
                       "route": "general/payment-complete/:requestId/:paymentId",
                       "pattern": "general/payment-complete/\\d+/\\d+",
                       "progress": 4
                     },
-                    { "route": "general/submit-complete", "progress": 5 }
+                    {
+                      "route": "general/submit-complete",
+                      "progress": 5
+                    }
                   ]
                 },
                 "noPaymentPath": {
                   "routes": [
-                    { "route": "general/ige/contact-info-options", "progress": 3 },
-                    { "route": "general/ige/review-submit", "progress": 4 }, 
-                    { "route": "general/ige/submit-complete", "progress": 5 }
+                    {
+                      "route": "general/ige/contact-info-options",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/ige/review-submit",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/ige/submit-complete",
+                      "progress": 5
+                    }
+                  ]
+                },
+                "legalProceedingPaymentPath": {
+                  "routes": [
+                    {
+                      "route": "general/legal-proceeding-details",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/contact-info-options",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/review-submit",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/payment",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/payment-complete/:requestId/:paymentId",
+                      "pattern": "general/payment-complete/\\d+/\\d+",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/submit-complete",
+                      "progress": 5
+                    }
+                  ]
+                },
+                "legalProceedingNoPaymentPath": {
+                  "routes": [
+                    {
+                      "route": "general/legal-proceeding-details",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/ige/contact-info-options",
+                      "progress": 3
+                    },
+                    {
+                      "route": "general/ige/review-submit",
+                      "progress": 4
+                    },
+                    {
+                      "route": "general/ige/submit-complete",
+                      "progress": 5
+                    }
                   ]
                 }
               }
@@ -366,113 +965,276 @@
         },
         "personal": {
           "routes": [
-            { "route": "choose-identity", "progress": 1 },
+            {
+              "route": "choose-identity",
+              "progress": 1
+            },
             {
               "route": "personal/select-about",
               "progress": 2,
               "choices": {
                 "yourself": {
                   "routes": [
-                    { "route": "personal/verify-your-identity", "progress": 2, "data": { "includeBirthDate": true } },
-                    { "route": "personal/request-topic","data": {"topics": "topicYourself" } ,  "progress": 2,
-                    "choices":{
-
-                      
-                      "childprotectionparent":{
-
-                        "routes":[
-                          { "route": "personal/childprotectionparent","progress": 2},
-                          { "route": "personal/childprotectionparent/ministry-confirmation","progress": 2},                        
-                          {"route": "personal/childprotectionparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/childprotectionparent/adoptive-parents","progress": 3},
-                          {"route": "personal/childprotectionparent/contact-info-options","progress": 3},
-                          { "route": "personal/childprotectionparent/review-submit", "progress": 4 },
-                          { "route": "personal/childprotectionparent/submit-complete", "progress": 6 }
-                        ]
-
-                      },
-                      "childprotectionchild":{
-                        "routes":[
-                          { "route": "personal/childprotectionchild","progress": 2},
-                          { "route": "personal/childprotectionchild/ministry-confirmation","progress": 2},
-                          {"route": "personal/childprotectionchild/description-timeframe","progress": 2},                     
-                          { "route": "personal/childprotectionchild/adoptive-parents","progress": 3},
-                          {"route": "personal/childprotectionchild/contact-info-options","progress": 3},
-                          { "route": "personal/childprotectionchild/review-submit", "progress": 4 },
-                          { "route": "personal/childprotectionchild/submit-complete", "progress": 6 }
-                        ]
-
-                      },
-                      "youthincareparent":{ "routes":[
-                        { "route": "personal/youthincareparent","progress": 2},
-                          { "route": "personal/youthincareparent/ministry-confirmation","progress": 2},
-                          {"route": "personal/youthincareparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/youthincareparent/adoptive-parents","progress": 3},
-                          {"route": "personal/youthincareparent/contact-info-options","progress": 3},
-                          { "route": "personal/youthincareparent/review-submit", "progress": 4 },
-                          { "route": "personal/youthincareparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "youthincarechild":{ "routes":[
-
-                        { "route": "personal/youthincarechild","progress": 2},
-                        { "route": "personal/youthincarechild/ministry-confirmation","progress": 3},
-                        {"route": "personal/youthincarechild/description-timeframe","progress": 2},                     
-                        { "route": "personal/youthincarechild/adoptive-parents","progress": 3},
-                        {"route": "personal/youthincarechild/contact-info-options","progress": 3},
-                        { "route": "personal/youthincarechild/review-submit", "progress": 4 },
-                        { "route": "personal/youthincarechild/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "fosterparent":{ "routes":[
-
-                        { "route": "personal/fosterparent","progress": 2},
-                        { "route": "personal/fosterparent/ministry-confirmation","progress": 2},
-                        {"route": "personal/fosterparent/description-timeframe","progress": 2},                     
-                        { "route": "personal/fosterparent/adoptive-parents","progress": 3},
-                        {"route": "personal/fosterparent/contact-info-options","progress": 3},
-                        { "route": "personal/fosterparent/review-submit", "progress": 4 },
-                        { "route": "personal/fosterparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "adoption":{ "routes":[
-                        { "route": "personal/adoption","progress": 2},
-                        { "route": "personal/adoption/ministry-confirmation","progress": 2},
-                        {"route": "personal/adoption/description-timeframe","progress": 2},                     
-                        { "route": "personal/adoption/adoptive-parents","progress": 3},
-                        {"route": "personal/adoption/contact-info-options","progress": 3},
-                        { "route": "personal/adoption/review-submit", "progress": 4 },
-                        { "route": "personal/adoption/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "others":{
-                        "routes":[
-                                    { "route": "personal/ministry-confirmation","progress": 2},
-                                    {"route": "personal/description-timeframe","progress": 2},                     
-                                    { "route": "personal/adoptive-parents","progress": 3},
-                                    {"route": "personal/contact-info-options","progress": 3},
-                                    { "route": "personal/review-submit", "progress": 4 },
-                                    { "route": "personal/submit-complete", "progress": 6 }
-                                  ]
+                    {
+                      "route": "personal/verify-your-identity",
+                      "progress": 2,
+                      "data": {
+                        "includeBirthDate": true
                       }
-                      
-
-
-                    }
-                    },   
-                              
-                    { "route": "personal/ministry-confirmation","progress": 2},
-                    {"route": "personal/description-timeframe","progress": 2},
-                     
-                    { "route": "personal/adoptive-parents","progress": 3},
+                    },
+                    {
+                      "route": "personal/request-topic",
+                      "data": {
+                        "topics": "topicYourself"
+                      },
+                      "progress": 2,
+                      "choices": {
+                        "childprotectionparent": {
+                          "routes": [
+                            {
+                              "route": "personal/childprotectionparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/childprotectionparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/childprotectionparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/childprotectionparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "childprotectionchild": {
+                          "routes": [
+                            {
+                              "route": "personal/childprotectionchild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionchild/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionchild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/childprotectionchild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/childprotectionchild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/childprotectionchild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/childprotectionchild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincareparent": {
+                          "routes": [
+                            {
+                              "route": "personal/youthincareparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/youthincareparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/youthincareparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/youthincareparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/youthincareparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/youthincareparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/youthincareparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincarechild": {
+                          "routes": [
+                            {
+                              "route": "personal/youthincarechild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/youthincarechild/ministry-confirmation",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/youthincarechild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/youthincarechild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/youthincarechild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/youthincarechild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/youthincarechild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "fosterparent": {
+                          "routes": [
+                            {
+                              "route": "personal/fosterparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/fosterparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/fosterparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/fosterparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/fosterparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/fosterparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/fosterparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "adoption": {
+                          "routes": [
+                            {
+                              "route": "personal/adoption",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/adoption/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/adoption/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/adoption/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/adoption/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/adoption/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/adoption/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "others": {
+                          "routes": [
+                            {
+                              "route": "personal/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        }
+                      }
+                    },
+                    {
+                      "route": "personal/ministry-confirmation",
+                      "progress": 2
+                    },
+                    {
+                      "route": "personal/description-timeframe",
+                      "progress": 2
+                    },
+                    {
+                      "route": "personal/adoptive-parents",
+                      "progress": 3
+                    },
                     {
                       "route": "personal/contact-info-options",
                       "progress": 3
                     },
-                    { "route": "personal/review-submit", "progress": 4 },
-                    { "route": "personal/submit-complete", "progress": 6 }
+                    {
+                      "route": "personal/review-submit",
+                      "progress": 4
+                    },
+                    {
+                      "route": "personal/submit-complete",
+                      "progress": 6
+                    }
                   ]
                 },
                 "child": {
@@ -522,7 +1284,10 @@
                       "route": "personal/child/review-submit",
                       "progress": 4
                     },
-                    { "route": "personal/child/submit-complete", "progress": 4 }
+                    {
+                      "route": "personal/child/submit-complete",
+                      "progress": 4
+                    }
                   ]
                 },
                 "another": {
@@ -599,94 +1364,235 @@
                         "includeBirthDate": true
                       }
                     },
-                    { "route": "personal/yourself-child/request-topic","data": {"topics": "topicYourselfChild" } ,  "progress": 2,
-                    "choices":{
-
-                      
-                      "childprotectionparent":{
-
-                        "routes":[
-                          { "route": "personal/yourself-child/childprotectionparent","progress": 2},
-                          { "route": "personal/yourself-child/childprotectionparent/ministry-confirmation","progress": 2},                        
-                          {"route": "personal/yourself-child/childprotectionparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child/childprotectionparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child/childprotectionparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child/childprotectionparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child/childprotectionparent/submit-complete", "progress": 6 }
-                        ]
-
+                    {
+                      "route": "personal/yourself-child/request-topic",
+                      "data": {
+                        "topics": "topicYourselfChild"
                       },
-                      "childprotectionchild":{
-                        "routes":[
-                          { "route": "personal/yourself-child/childprotectionchild","progress": 2},
-                          { "route": "personal/yourself-child/childprotectionchild/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-child/childprotectionchild/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child/childprotectionchild/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child/childprotectionchild/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child/childprotectionchild/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child/childprotectionchild/submit-complete", "progress": 6 }
-                        ]
-
-                      },
-                      "youthincareparent":{ "routes":[
-                        { "route": "personal/yourself-child/youthincareparent","progress": 2},
-                          { "route": "personal/yourself-child/youthincareparent/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-child/youthincareparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child/youthincareparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child/youthincareparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child/youthincareparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child/youthincareparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "youthincarechild":{ "routes":[
-
-                        { "route": "personal/yourself-child/youthincarechild","progress": 2},
-                        { "route": "personal/yourself-child/youthincarechild/ministry-confirmation","progress": 3},
-                        {"route": "personal/yourself-child/youthincarechild/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child/youthincarechild/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child/youthincarechild/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child/youthincarechild/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child/youthincarechild/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "fosterparent":{ "routes":[
-
-                        { "route": "personal/yourself-child/fosterparent","progress": 2},
-                        { "route": "personal/yourself-child/fosterparent/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-child/fosterparent/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child/fosterparent/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child/fosterparent/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child/fosterparent/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child/fosterparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "adoption":{ "routes":[
-                        { "route": "personal/yourself-child/adoption","progress": 2},
-                        { "route": "personal/yourself-child/adoption/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-child/adoption/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child/adoption/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child/adoption/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child/adoption/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child/adoption/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "others":{
-                        "routes":[
-                                    { "route": "personal/yourself-child/ministry-confirmation","progress": 2},
-                                    {"route": "personal/yourself-child/description-timeframe","progress": 2},                     
-                                    { "route": "personal/yourself-child/adoptive-parents","progress": 3},
-                                    {"route": "personal/yourself-child/contact-info-options","progress": 3},
-                                    { "route": "personal/yourself-child/review-submit", "progress": 4 },
-                                    { "route": "personal/yourself-child/submit-complete", "progress": 6 }
-                                  ]
+                      "progress": 2,
+                      "choices": {
+                        "childprotectionparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/childprotectionparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "childprotectionchild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/childprotectionchild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/childprotectionchild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincareparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/youthincareparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincareparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincarechild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/youthincarechild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/ministry-confirmation",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/youthincarechild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "fosterparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/fosterparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/fosterparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "adoption": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/adoption",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/adoption/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "others": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        }
                       }
-                      
-
-
-                    }
-                    }, 
+                    },
                     {
                       "route": "personal/yourself-child/ministry-confirmation",
                       "progress": 2
@@ -734,94 +1640,235 @@
                         "includeBirthDate": true
                       }
                     },
-                    { "route": "personal/yourself-another/request-topic","data": {"topics": "topicYourselfAnother" } ,  "progress": 2,
-                    "choices":{
-
-                      
-                      "childprotectionparent":{
-
-                        "routes":[
-                          { "route": "personal/yourself-another/childprotectionparent","progress": 2},
-                          { "route": "personal/yourself-another/childprotectionparent/ministry-confirmation","progress": 2},                        
-                          {"route": "personal/yourself-another/childprotectionparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-another/childprotectionparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-another/childprotectionparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-another/childprotectionparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-another/childprotectionparent/submit-complete", "progress": 6 }
-                        ]
-
+                    {
+                      "route": "personal/yourself-another/request-topic",
+                      "data": {
+                        "topics": "topicYourselfAnother"
                       },
-                      "childprotectionchild":{
-                        "routes":[
-                          { "route": "personal/yourself-another/childprotectionchild","progress": 2},
-                          { "route": "personal/yourself-another/childprotectionchild/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-another/childprotectionchild/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-another/childprotectionchild/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-another/childprotectionchild/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-another/childprotectionchild/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-another/childprotectionchild/submit-complete", "progress": 6 }
-                        ]
-
-                      },
-                      "youthincareparent":{ "routes":[
-                        { "route": "personal/yourself-another/youthincareparent","progress": 2},
-                          { "route": "personal/yourself-another/youthincareparent/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-another/youthincareparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-another/youthincareparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-another/youthincareparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-another/youthincareparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-another/youthincareparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "youthincarechild":{ "routes":[
-
-                        { "route": "personal/yourself-another/youthincarechild","progress": 2},
-                        { "route": "personal/yourself-another/youthincarechild/ministry-confirmation","progress": 3},
-                        {"route": "personal/yourself-another/youthincarechild/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-another/youthincarechild/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-another/youthincarechild/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-another/youthincarechild/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-another/youthincarechild/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "fosterparent":{ "routes":[
-
-                        { "route": "personal/yourself-another/fosterparent","progress": 2},
-                        { "route": "personal/yourself-another/fosterparent/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-another/fosterparent/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-another/fosterparent/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-another/fosterparent/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-another/fosterparent/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-another/fosterparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "adoption":{ "routes":[
-                        { "route": "personal/yourself-another/adoption","progress": 2},
-                        { "route": "personal/yourself-another/adoption/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-another/adoption/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-another/adoption/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-another/adoption/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-another/adoption/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-another/adoption/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "others":{
-                        "routes":[
-                                    { "route": "personal/yourself-another/ministry-confirmation","progress": 2},
-                                    {"route": "personal/yourself-another/description-timeframe","progress": 2},                     
-                                    { "route": "personal/yourself-another/adoptive-parents","progress": 3},
-                                    {"route": "personal/yourself-another/contact-info-options","progress": 3},
-                                    { "route": "personal/yourself-another/review-submit", "progress": 4 },
-                                    { "route": "personal/yourself-another/submit-complete", "progress": 6 }
-                                  ]
+                      "progress": 2,
+                      "choices": {
+                        "childprotectionparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/childprotectionparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "childprotectionchild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/childprotectionchild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/childprotectionchild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincareparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/youthincareparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincareparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincarechild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/youthincarechild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/ministry-confirmation",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/youthincarechild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "fosterparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/fosterparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/fosterparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "adoption": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/adoption",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/adoption/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "others": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-another/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-another/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-another/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-another/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        }
                       }
-                      
-
-
-                    }
-                    },  
+                    },
                     {
                       "route": "personal/yourself-another/ministry-confirmation",
                       "progress": 2
@@ -880,93 +1927,234 @@
                         "includeBirthDate": true
                       }
                     },
-                    { "route": "personal/yourself-child-another/request-topic","data": {"topics": "topicYourselfChildAnother" } ,  "progress": 2,
-                    "choices":{
-
-                      
-                      "childprotectionparent":{
-
-                        "routes":[
-                          { "route": "personal/yourself-child-another/childprotectionparent","progress": 2},
-                          { "route": "personal/yourself-child-another/childprotectionparent/ministry-confirmation","progress": 2},                        
-                          {"route": "personal/yourself-child-another/childprotectionparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child-another/childprotectionparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child-another/childprotectionparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child-another/childprotectionparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child-another/childprotectionparent/submit-complete", "progress": 6 }
-                        ]
-
+                    {
+                      "route": "personal/yourself-child-another/request-topic",
+                      "data": {
+                        "topics": "topicYourselfChildAnother"
                       },
-                      "childprotectionchild":{
-                        "routes":[
-                          { "route": "personal/yourself-child-another/childprotectionchild","progress": 2},
-                          { "route": "personal/yourself-child-another/childprotectionchild/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-child-another/childprotectionchild/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child-another/childprotectionchild/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child-another/childprotectionchild/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child-another/childprotectionchild/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child-another/childprotectionchild/submit-complete", "progress": 6 }
-                        ]
-
-                      },
-                      "youthincareparent":{ "routes":[
-                        { "route": "personal/yourself-child-another/youthincareparent","progress": 2},
-                          { "route": "personal/yourself-child-another/youthincareparent/ministry-confirmation","progress": 2},
-                          {"route": "personal/yourself-child-another/youthincareparent/description-timeframe","progress": 2},                     
-                          { "route": "personal/yourself-child-another/youthincareparent/adoptive-parents","progress": 3},
-                          {"route": "personal/yourself-child-another/youthincareparent/contact-info-options","progress": 3},
-                          { "route": "personal/yourself-child-another/youthincareparent/review-submit", "progress": 4 },
-                          { "route": "personal/yourself-child-another/youthincareparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "youthincarechild":{ "routes":[
-
-                        { "route": "personal/yourself-child-another/youthincarechild","progress": 2},
-                        { "route": "personal/yourself-child-another/youthincarechild/ministry-confirmation","progress": 3},
-                        {"route": "personal/yourself-child-another/youthincarechild/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child-another/youthincarechild/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child-another/youthincarechild/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child-another/youthincarechild/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child-another/youthincarechild/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "fosterparent":{ "routes":[
-
-                        { "route": "personal/yourself-child-another/fosterparent","progress": 2},
-                        { "route": "personal/yourself-child-another/fosterparent/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-child-another/fosterparent/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child-another/fosterparent/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child-another/fosterparent/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child-another/fosterparent/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child-another/fosterparent/submit-complete", "progress": 6 }
-
-                      ]},
-                      "adoption":{ "routes":[
-                        { "route": "personal/yourself-child-another/adoption","progress": 2},
-                        { "route": "personal/yourself-child-another/adoption/ministry-confirmation","progress": 2},
-                        {"route": "personal/yourself-child-another/adoption/description-timeframe","progress": 2},                     
-                        { "route": "personal/yourself-child-another/adoption/adoptive-parents","progress": 3},
-                        {"route": "personal/yourself-child-another/adoption/contact-info-options","progress": 3},
-                        { "route": "personal/yourself-child-another/adoption/review-submit", "progress": 4 },
-                        { "route": "personal/yourself-child-another/adoption/submit-complete", "progress": 6 }
-
-
-                      ]},
-                      "others":{
-                        "routes":[
-                                    { "route": "personal/yourself-child-another/ministry-confirmation","progress": 2},
-                                    {"route": "personal/yourself-child-another/description-timeframe","progress": 2},                     
-                                    { "route": "personal/yourself-child-another/adoptive-parents","progress": 3},
-                                    {"route": "personal/yourself-child-another/contact-info-options","progress": 3},
-                                    { "route": "personal/yourself-child-another/review-submit", "progress": 4 },
-                                    { "route": "personal/yourself-child-another/submit-complete", "progress": 6 }
-                                  ]
+                      "progress": 2,
+                      "choices": {
+                        "childprotectionparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "childprotectionchild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/childprotectionchild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincareparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincareparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "youthincarechild": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/ministry-confirmation",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/youthincarechild/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "fosterparent": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/fosterparent",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/fosterparent/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "adoption": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/adoption",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoption/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        },
+                        "others": {
+                          "routes": [
+                            {
+                              "route": "personal/yourself-child-another/ministry-confirmation",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/description-timeframe",
+                              "progress": 2
+                            },
+                            {
+                              "route": "personal/yourself-child-another/adoptive-parents",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/contact-info-options",
+                              "progress": 3
+                            },
+                            {
+                              "route": "personal/yourself-child-another/review-submit",
+                              "progress": 4
+                            },
+                            {
+                              "route": "personal/yourself-child-another/submit-complete",
+                              "progress": 6
+                            }
+                          ]
+                        }
                       }
-                      
-
-
-                    }
                     },
                     {
                       "route": "personal/yourself-child-another/ministry-confirmation",


### PR DESCRIPTION
Summary:
- Added mandatory law firm question to general contact info page.
- Added conditional legal proceeding questions for law firm applicants.
- Added certification name requirement when law firm is not involved in a proceeding.
- Added court/tribunal, file number, and proceeding type fields when law firm is involved in a proceeding.
- Added legal proceeding details page for law firm + proceeding path.
- Added generated email section for law firm legal proceeding details.
- Added/updated email layout tests.

Testing:
- Manual tested general request contact flow:
  - Law firm = No routes normally.
  - Law firm = Yes + legal proceeding = No requires certification name and routes normally.
  - Law firm = Yes + legal proceeding = Yes routes to legal proceeding details page.
  - Legal proceeding details page requires related proceeding answer.
  - Party question appears and is required when related proceeding is Yes.
- Manual tested personal request flow: law firm questions do not appear.
- API email layout test:
  docker compose run --rm --entrypoint npm api test -- test/emailLayout.spec.js
  Result: 27 passing.