### PR TITLE
Ticket 2470: Send user to homepage and clear state on duplicate request data

### DIFF
--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -98,14 +98,12 @@ export class ReviewSubmitComponent implements OnInit {
         // Handle duplicate request
         if (error.status === 409) {
           alert(
-            `${error.message}.\n\n` +
-            "This request was already submitted.\n\n" +
-            "To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
-            "Go back to the homepage and start a new request."
+            "Duplicate request identified. Request was not processed.\n\n" +
+            "This request has already been submitted. To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
+            "Go back to the homepage and start a new request to try again."
           );
-          // this.captchaComponent.forceRefresh();
-          // this.captchaComplete = false;
-          // this.isBusy = false;
+          this.dataService.clearState();
+          this.base.goHome();
           return;
         }
 

--- a/web/src/app/utils-components/base/base.component.ts
+++ b/web/src/app/utils-components/base/base.component.ts
@@ -74,6 +74,10 @@ export class BaseComponent implements OnInit {
     // }
   }
 
+  goHome() {
+    this.router.navigate([''])
+  }
+
   goSkipForward() {   
     this.foiRouter.progress({ direction: 2 });
   }


### PR DESCRIPTION
Added additional logic to duplicate request handling for FE for user -> if duplicate request is found , send user to webform homepage as well as clear all foirequest data.