### PR TITLE
Ticket 2470: Keycloak Logout changes + added logout on duplicate request if KC user exists

### DIFF
--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -85,16 +85,13 @@ export class ReviewSubmitComponent implements OnInit {
 
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
-          const requestType = this.foiRequest.requestData.requestType;
-          // Clear request state so a duplicate submission cannot resubmit the same data
-          this.dataService.clearState({requestType: requestType});
-          this.keycloakService.logout();
+          this.dataService.clearState()
+          this.keycloakService.logout(window.location.origin + '/personal/submit-complete');
         } else {
           this.base.goFoiForward();
         }
       },
       (error) => {
-        console.log("VERIFY", error)
         // Handle duplicate request
         if (error.status === 409) {
           alert(
@@ -103,10 +100,15 @@ export class ReviewSubmitComponent implements OnInit {
             "Go back to the homepage and start a new request to try again."
           );
           this.dataService.clearState();
-          this.base.goHome();
-          return;
+          if (this.keycloakService.isAuthenticated()) {
+            this.keycloakService.logout(window.location.origin);
+            return;
+          } else {
+            this.base.goHome();
+            return;
+          }
         }
-
+        
         this.isBusy = false;
         alert("Temporarily unable to submit your request. Please try again in a few minutes.");
         this.captchaComponent.forceRefresh();

--- a/web/src/app/services/keycloak.service.ts
+++ b/web/src/app/services/keycloak.service.ts
@@ -121,24 +121,25 @@ export class KeycloakService {
     return token !== undefined && token.sub !== undefined;
   }
 
-  logout() {
+  logout(redirectUrl: string) {
     if (this.isAuthenticated()) {
       if (!this.keycloakAuth) {
         this.keycloakAuth = new Keycloak(this.keycloakConfig);
         this.keycloakAuth.init({token: sessionStorage.getItem('KC_TOKEN'), onLoad: 'check-sso'})
         .then(authenticated => {
           if (authenticated) {
-            this.logoutUser();
+            this.logoutUser(redirectUrl);
           }
         });
       } else {
-        this.logoutUser();
+        this.logoutUser(redirectUrl);
       }
     }
   }
 
-  logoutUser() {
-    const redirectUrl = window.location.origin + '/general/submit-complete';
+  logoutUser(redirectUrl: string) {
+    sessionStorage.removeItem('KC_TOKEN');
+    sessionStorage.removeItem('KC_REFRESH');
     this.keycloakAuth.logout({ redirectUri: redirectUrl });
   }
 }


### PR DESCRIPTION
1. Redirect url for logging out user from Keycloak is now dynamic
2. Redirect url for logging out a user for 200 status request goes to /personal/ where before it went to /general/
3. logoutUser function which logs out the user from KC also remove KC related session storage items which were not being cleared on logout leading to issues. We manually set these in our code base when keycloak is init.
4. Revised duplicate request handling where if the user was logged in via KC, log them out as well as clearing form data and sending them back to home.