### PR TITLE
Release 25.13 (Ticket 2470) - Request Deduplicate Service

### DIFF
--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -75,23 +75,22 @@ const submitFoiRequest = async (server, req, res, next) => {
         pendingPayment: false
       });
 
-    }
-    else if (response.status === 409) {
-      // Handle duplicate request
-      console.log(response.data.message);
-      res.send({
-        EmailSuccess: false,
-        message: response.data.message,
-        pendingPayment: false
-      });
-    }
-    else {
+    } else {
       req.log.info('Failed:', response);
       const unavailable = new restifyErrors.ServiceUnavailableError('Service is unavailable.');
       return next(unavailable);
     }  
   }
    catch(error){
+    if (error.response.status === 409) {
+      // Handle duplicate request
+      console.log(error.response.data.message);
+      res.send({
+        EmailSuccess: false,
+        message: response.data.message,
+        pendingPayment: false
+      });
+    }
      console.log(`${error}`);
      console.log("FOI API STATUS:", error.response.status);
      console.log("FOI API DATA:", error.response.data)

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -54,9 +54,9 @@ const submitFoiRequest = async (server, req, res, next) => {
     console.log("calling RAW FOI Request");
     const response =  await requestAPI.invokeRequestAPI(JSON.stringify(data.params), apiUrl);
   
-    console.log(`API response = ${response.status}`);
+    console.log(`API response = DATA: ${response.data}, STATUS: ${response.status}`);
 
-    if(response.status === 200  && response.data.status ) {
+    if(response.status === 200  && response.data.status) {
       console.log(`response id: ${response.data.id}`);
       // if request needs payment, return earlier to prevent sending email as it will be sent after payment.
       if(needsPayment) {
@@ -76,6 +76,15 @@ const submitFoiRequest = async (server, req, res, next) => {
       });
 
     }
+    else if (response.status === 409) {
+      // Handle duplicate request
+      console.log(response.data.message);
+      res.send({
+        EmailSuccess: false,
+        message: response.data.message,
+        pendingPayment: false
+      });
+    }
     else {
       req.log.info('Failed:', response);
       const unavailable = new restifyErrors.ServiceUnavailableError('Service is unavailable.');
@@ -93,6 +102,12 @@ const submitFoiRequest = async (server, req, res, next) => {
 }
 
 const submitFoiRequestEmail = async (server, req, res, next) => {
+  console.log(
+    '[API]',
+    new Date().toISOString(),
+    'submitFoiRequestEmail API called'
+  );
+  console.trace('submitFoiRequestEmail API');
 
   req.params.requestData = JSON.parse(req.params.requestData);
   

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -81,22 +81,19 @@ const submitFoiRequest = async (server, req, res, next) => {
       return next(unavailable);
     }  
   }
-   catch(error){
+   catch(error) {
+    console.log(`${error}`);
+    console.log("FOI API STATUS:", error.response.status);
+    console.log("FOI API DATA:", error.response.data);
+    req.log.info('Failed:', error);
+    
     if (error.response.status === 409) {
       // Handle duplicate request
-      res.send({
-        EmailSuccess: false,
-        message: error.response.data.message,
-        pendingPayment: false
-      });
-      return;
+      const unavailable = new restifyErrors.ConflictError(error.response.data.message);
+    } else {
+      const unavailable = new restifyErrors.ServiceUnavailableError(error.message || 'Service is unavailable.');
     }
-     console.log(`${error}`);
-     console.log("FOI API STATUS:", error.response.status);
-     console.log("FOI API DATA:", error.response.data)
-     req.log.info('Failed:', error);
-     const unavailable = new restifyErrors.ServiceUnavailableError(error.message || 'Service is unavailable.');
-     return next(unavailable);
+    return next(unavailable);
    }
 }
 

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -17,7 +17,6 @@ const maxAttachBytes = MAX_ATTACH_MB * 1024 * 1024;
 
 const submitFoiRequest = async (server, req, res, next) => {
   console.count("COUNT: submitFoiRequest API CALL");
-  console.log("submitFoiRequest API DATA", req);
   console.trace('TRACE: submitFoiRequest API CALL');
   
   const apiUrl = `${foiRequestAPIBackend}/foirawrequests`;  

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -54,7 +54,7 @@ const submitFoiRequest = async (server, req, res, next) => {
     console.log("calling RAW FOI Request");
     const response =  await requestAPI.invokeRequestAPI(JSON.stringify(data.params), apiUrl);
   
-    console.log(`API response = DATA: ${response.data}, STATUS: ${response.status}`);
+    console.log(`API response = DATA: ${JSON.stringify(response.data)}, STATUS: ${response.status}`);
 
     if(response.status === 200  && response.data.status) {
       console.log(`response id: ${response.data.id}`);

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -16,6 +16,9 @@ const MAX_ATTACH_MB = 5;
 const maxAttachBytes = MAX_ATTACH_MB * 1024 * 1024;
 
 const submitFoiRequest = async (server, req, res, next) => {
+  console.count("COUNT: submitFoiRequest API CALL");
+  console.log("submitFoiRequest API DATA", req);
+  console.trace('TRACE: submitFoiRequest API CALL');
   
   const apiUrl = `${foiRequestAPIBackend}/foirawrequests`;  
 

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -16,8 +16,12 @@ const MAX_ATTACH_MB = 5;
 const maxAttachBytes = MAX_ATTACH_MB * 1024 * 1024;
 
 const submitFoiRequest = async (server, req, res, next) => {
-  console.count("COUNT: submitFoiRequest API CALL");
-  console.trace('TRACE: submitFoiRequest API CALL');
+  console.log(
+    '[API]',
+    new Date().toISOString(),
+    'submitFoiRequest API called'
+  );
+  console.trace('submitFoiRequest API');
   
   const apiUrl = `${foiRequestAPIBackend}/foirawrequests`;  
 

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -86,12 +86,12 @@ const submitFoiRequest = async (server, req, res, next) => {
     console.log("FOI API STATUS:", error.response.status);
     console.log("FOI API DATA:", error.response.data);
     req.log.info('Failed:', error);
-    
+    let unavailable = "";
     if (error.response.status === 409) {
       // Handle duplicate request
-      const unavailable = new restifyErrors.ConflictError(error.response.data.message);
+      unavailable = new restifyErrors.ConflictError(error.response.data.message);
     } else {
-      const unavailable = new restifyErrors.ServiceUnavailableError(error.message || 'Service is unavailable.');
+      unavailable = new restifyErrors.ServiceUnavailableError(error.message || 'Service is unavailable.');
     }
     return next(unavailable);
    }

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -84,12 +84,12 @@ const submitFoiRequest = async (server, req, res, next) => {
    catch(error){
     if (error.response.status === 409) {
       // Handle duplicate request
-      console.log(error.response.data.message);
       res.send({
         EmailSuccess: false,
-        message: response.data.message,
+        message: error.response.data.message,
         pendingPayment: false
       });
+      return;
     }
      console.log(`${error}`);
      console.log("FOI API STATUS:", error.response.status);

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -118,7 +118,6 @@ export class PaymentCompleteComponent implements OnInit {
     console.trace('PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
       (response) => {
-        console.log("submitFoiRequest Response: ", response);
         const result = response.body;
         if (!result.EmailSuccess) {
           alert("Temporarily unable to complete your request. Please contact us to complete your request.");

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -110,8 +110,12 @@ export class PaymentCompleteComponent implements OnInit {
   }
 
   submitEmail() {
-    console.count('COUNT: SUBMIT PAYMENT EMAIL COMPONENT CALLED');
-    console.trace('TRACE: SUBMIT PAYMENT EMAIL COMPONENT');
+    console.log(
+      '[PAYMENT-COMPLETED COMPONENT]',
+      new Date().toISOString(),
+      'Payment completed request submitted'
+    );
+    console.trace('PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
       (result) => {
         if (!result.EmailSuccess) {

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -117,7 +117,9 @@ export class PaymentCompleteComponent implements OnInit {
     );
     console.trace('PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
-      (result) => {
+      (response) => {
+        console.log("submitFoiRequest Response: ", response)
+        const result = response.body;
         if (!result.EmailSuccess) {
           alert("Temporarily unable to complete your request. Please contact us to complete your request.");
         }

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -110,6 +110,8 @@ export class PaymentCompleteComponent implements OnInit {
   }
 
   submitEmail() {
+    console.count('COUNT: SUBMIT PAYMENT EMAIL COMPONENT CALLED');
+    console.trace('TRACE: SUBMIT PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
       (result) => {
         if (!result.EmailSuccess) {

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -117,9 +117,7 @@ export class PaymentCompleteComponent implements OnInit {
     );
     console.trace('PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
-      (response) => {
-        console.log("submitFoiRequest Response: ", response)
-        const result = response.body;
+      (result) => {
         if (!result.EmailSuccess) {
           alert("Temporarily unable to complete your request. Please contact us to complete your request.");
         }

--- a/web/src/app/route-components/payment-complete/payment-complete.component.ts
+++ b/web/src/app/route-components/payment-complete/payment-complete.component.ts
@@ -117,7 +117,9 @@ export class PaymentCompleteComponent implements OnInit {
     );
     console.trace('PAYMENT EMAIL COMPONENT');
     this.dataService.submitRequest(this.authToken, null, this.foiRequest, true).subscribe(
-      (result) => {
+      (response) => {
+        console.log("submitFoiRequest Response: ", response);
+        const result = response.body;
         if (!result.EmailSuccess) {
           alert("Temporarily unable to complete your request. Please contact us to complete your request.");
         }

--- a/web/src/app/route-components/review-submit-complete/review-submit-complete.component.ts
+++ b/web/src/app/route-components/review-submit-complete/review-submit-complete.component.ts
@@ -26,13 +26,7 @@ export class ReviewSubmitCompleteComponent implements OnInit {
     this.foiRequest.requestData.requestType.youthincareparent = [];
 
     // Clear the current state!
-    const blankState: FoiRequest = {
-      requestData: {},
-    };
-    this.dataService.setCurrentState(blankState);
-    this.dataService.removeChildFileAttachment();
-    this.dataService.removePersonFileAttachment();
-    this.dataService.removeAdoptionFileAttachment();
+    this.dataService.clearState();
     this.dataService.removeAuthToken();
   }
 

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -85,16 +85,13 @@ export class ReviewSubmitComponent implements OnInit {
 
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
-          const requestType = this.foiRequest.requestData.requestType;
-          // Clear request state so a duplicate submission cannot resubmit the same data
-          this.dataService.clearState({requestType: requestType});
-          this.keycloakService.logout();
+          this.dataService.clearState()
+          this.keycloakService.logout(window.location.origin + '/personal/submit-complete');
         } else {
           this.base.goFoiForward();
         }
       },
       (error) => {
-        console.log("VERIFY", error)
         // Handle duplicate request
         if (error.status === 409) {
           alert(
@@ -103,10 +100,15 @@ export class ReviewSubmitComponent implements OnInit {
             "Go back to the homepage and start a new request to try again."
           );
           this.dataService.clearState();
-          this.base.goHome();
-          return;
+          if (this.keycloakService.isAuthenticated()) {
+            this.keycloakService.logout(window.location.origin);
+            return;
+          } else {
+            this.base.goHome();
+            return;
+          }
         }
-
+        
         this.isBusy = false;
         alert("Temporarily unable to submit your request. Please try again in a few minutes.");
         this.captchaComponent.forceRefresh();

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -77,20 +77,7 @@ export class ReviewSubmitComponent implements OnInit {
       (response) => {
         const result = response.body;
         console.log("submitFoiRequest Response: ", response);
-        // Handle duplicate request
-        if (response.status === 409) {
-          alert(
-            `${result.message}.\n\n` +
-            "This request was already submitted.\n\n" +
-            "To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
-            "Go back to the homepage and start a new request."
-          );
-          // this.captchaComponent.forceRefresh();
-          // this.captchaComplete = false;
-          // this.isBusy = false;
-          return;
-        }
-        
+
         this.foiRequest.requestData.requestId = result.id;
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
@@ -107,8 +94,22 @@ export class ReviewSubmitComponent implements OnInit {
         }
       },
       (error) => {
-        this.isBusy = false;
+        console.log("VERIFY", error)
+        // Handle duplicate request
+        if (error.status === 409) {
+          alert(
+            `${error.message}.\n\n` +
+            "This request was already submitted.\n\n" +
+            "To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
+            "Go back to the homepage and start a new request."
+          );
+          // this.captchaComponent.forceRefresh();
+          // this.captchaComplete = false;
+          // this.isBusy = false;
+          return;
+        }
 
+        this.isBusy = false;
         alert("Temporarily unable to submit your request. Please try again in a few minutes.");
         this.captchaComponent.forceRefresh();
         this.captchaComplete = false;

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -61,12 +61,16 @@ export class ReviewSubmitComponent implements OnInit {
   }
 
   doContinue() {
-    console.count("COUNT: REQUEST SUBMIT COMPONENT CALLED");
+    console.log(
+      '[REVIEW-SUBMIT COMPONENT]',
+      new Date().toISOString(),
+      'Submitting request'
+    );
     if (this.isBusy) {
-      console.trace('TRACE: REQUEST SUBMIT COMPONENT BLOCKED');
+      console.trace('REQUEST-SUBMIT COMPONENT BLOCKED');
       return;
     }
-    console.trace('TRACE: REQUEST SUBMIT COMPONENT ALLOWED');
+    console.trace('REQUEST-SUBMIT COMPONENT ALLOWED');
     
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -74,10 +74,11 @@ export class ReviewSubmitComponent implements OnInit {
     
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
-      (result) => {
-        console.log("submitFoiRequest Response: ", result)
+      (response) => {
+        const result = response.body;
+        console.log("submitFoiRequest Response: ", response);
         // Handle duplicate request
-        if (!result.status) {
+        if (response.status === 409) {
           alert(
             `${result.message}.\n\n` +
             "This request was already submitted.\n\n" +

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -76,7 +76,6 @@ export class ReviewSubmitComponent implements OnInit {
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
       (response) => {
         const result = response.body;
-        console.log("submitFoiRequest Response: ", response);
 
         this.foiRequest.requestData.requestId = result.id;
         this.dataService.setCurrentState(this.foiRequest);

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -61,6 +61,13 @@ export class ReviewSubmitComponent implements OnInit {
   }
 
   doContinue() {
+    console.count("COUNT: REQUEST SUBMIT COMPONENT CALLED");
+    if (this.isBusy) {
+      console.trace('TRACE: REQUEST SUBMIT COMPONENT BLOCKED');
+      return;
+    }
+    console.trace('TRACE: REQUEST SUBMIT COMPONENT ALLOWED');
+    
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
       (result) => {
@@ -68,9 +75,11 @@ export class ReviewSubmitComponent implements OnInit {
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
 
-        this.isBusy = false;
+        // this.isBusy = false;
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
+          // Clear request state so a duplicate submission cannot resubmit the same data
+          this.dataService.clearState();
           this.keycloakService.logout();
         } else {
           this.base.goFoiForward();
@@ -82,11 +91,6 @@ export class ReviewSubmitComponent implements OnInit {
         alert("Temporarily unable to submit your request. Please try again in a few minutes.");
         this.captchaComponent.forceRefresh();
         this.captchaComplete = false;
-        // if (this.keycloakService.isAuthenticated()) {
-        //   this.keycloakService.logout();
-        // } else {
-        //   this.base.goFoiForward();
-        // }
       }
     );
   }

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -74,11 +74,10 @@ export class ReviewSubmitComponent implements OnInit {
     
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
-      (response) => {
-        const result = response.body;
-        console.log("submitFoiRequest Response: ", response)
+      (result) => {
+        console.log("submitFoiRequest Response: ", result)
         // Handle duplicate request
-        if (response.status === 409) {
+        if (!result.status) {
           alert(
             `${result.message}.\n\n` +
             "This request was already submitted.\n\n" +

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -82,8 +82,9 @@ export class ReviewSubmitComponent implements OnInit {
         // this.isBusy = false;
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
+          const requestType = this.foiRequest.requestData.requestType;
           // Clear request state so a duplicate submission cannot resubmit the same data
-          this.dataService.clearState();
+          this.dataService.clearState({requestType: requestType});
           this.keycloakService.logout();
         } else {
           this.base.goFoiForward();

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -98,14 +98,12 @@ export class ReviewSubmitComponent implements OnInit {
         // Handle duplicate request
         if (error.status === 409) {
           alert(
-            `${error.message}.\n\n` +
-            "This request was already submitted.\n\n" +
-            "To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
-            "Go back to the homepage and start a new request."
+            "Duplicate request identified. Request was not processed.\n\n" +
+            "This request has already been submitted. To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
+            "Go back to the homepage and start a new request to try again."
           );
-          // this.captchaComponent.forceRefresh();
-          // this.captchaComplete = false;
-          // this.isBusy = false;
+          this.dataService.clearState();
+          this.base.goHome();
           return;
         }
 

--- a/web/src/app/route-components/review-submit/review-submit.component.ts
+++ b/web/src/app/route-components/review-submit/review-submit.component.ts
@@ -74,12 +74,28 @@ export class ReviewSubmitComponent implements OnInit {
     
     this.isBusy = true;
     this.dataService.submitRequest(this.authToken, this.captchaNonce, this.foiRequest).subscribe(
-      (result) => {
+      (response) => {
+        const result = response.body;
+        console.log("submitFoiRequest Response: ", response)
+        // Handle duplicate request
+        if (response.status === 409) {
+          alert(
+            `${result.message}.\n\n` +
+            "This request was already submitted.\n\n" +
+            "To prevent duplicates, you cannot resubmit the same request for 30 minutes.\n\n" +
+            "Go back to the homepage and start a new request."
+          );
+          // this.captchaComponent.forceRefresh();
+          // this.captchaComplete = false;
+          // this.isBusy = false;
+          return;
+        }
+        
         this.foiRequest.requestData.requestId = result.id;
         this.dataService.setCurrentState(this.foiRequest);
         this.dataService.saveAuthToken(this.authToken);
-
         // this.isBusy = false;
+
         // If the user is authenticated, logout the user
         if (this.keycloakService.isAuthenticated()) {
           const requestType = this.foiRequest.requestData.requestType;

--- a/web/src/app/services/data.service.ts
+++ b/web/src/app/services/data.service.ts
@@ -301,8 +301,12 @@ export class DataService {
    * @param foiRequest - A structure containing the complete request
    */
   submitRequest(authToken: string, nonce: string, foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
-    console.count('COUNT: submitRequest FUNCTION');
-    console.trace('TRACE: submitRequest FUNCTION');
+    console.log(
+      '[DATA SERVICE]',
+      new Date().toISOString(),
+      'submitRequest called'
+    );
+    console.trace('submitRequest FUNCTION');
     this.apiClient.setHeader("Authorization", "Bearer " + authToken);
     if (nonce) {
       

--- a/web/src/app/services/data.service.ts
+++ b/web/src/app/services/data.service.ts
@@ -143,8 +143,8 @@ export class DataService {
     return foi;
   }
 
-  clearState() {
-    const blankState: FoiRequest = { requestData: {} };
+  clearState(newData = {}) {
+    const blankState: FoiRequest = { requestData: newData };
     this.setCurrentState(blankState);
     this.removeChildFileAttachment();
     this.removePersonFileAttachment();

--- a/web/src/app/services/data.service.ts
+++ b/web/src/app/services/data.service.ts
@@ -143,6 +143,14 @@ export class DataService {
     return foi;
   }
 
+  clearState() {
+    const blankState: FoiRequest = { requestData: {} };
+    this.setCurrentState(blankState);
+    this.removeChildFileAttachment();
+    this.removePersonFileAttachment();
+    this.removeAdoptionFileAttachment();
+  }
+
   setChildFileAttachment(f: File): Observable<boolean> {
     return new Observable((observer) => {
       const reader: FileReader = new FileReader();
@@ -293,6 +301,8 @@ export class DataService {
    * @param foiRequest - A structure containing the complete request
    */
   submitRequest(authToken: string, nonce: string, foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
+    console.count('COUNT: submitRequest FUNCTION');
+    console.trace('TRACE: submitRequest FUNCTION');
     this.apiClient.setHeader("Authorization", "Bearer " + authToken);
     if (nonce) {
       

--- a/web/src/app/services/keycloak.service.ts
+++ b/web/src/app/services/keycloak.service.ts
@@ -121,24 +121,25 @@ export class KeycloakService {
     return token !== undefined && token.sub !== undefined;
   }
 
-  logout() {
+  logout(redirectUrl: string) {
     if (this.isAuthenticated()) {
       if (!this.keycloakAuth) {
         this.keycloakAuth = new Keycloak(this.keycloakConfig);
         this.keycloakAuth.init({token: sessionStorage.getItem('KC_TOKEN'), onLoad: 'check-sso'})
         .then(authenticated => {
           if (authenticated) {
-            this.logoutUser();
+            this.logoutUser(redirectUrl);
           }
         });
       } else {
-        this.logoutUser();
+        this.logoutUser(redirectUrl);
       }
     }
   }
 
-  logoutUser() {
-    const redirectUrl = window.location.origin + '/general/submit-complete';
+  logoutUser(redirectUrl: string) {
+    sessionStorage.removeItem('KC_TOKEN');
+    sessionStorage.removeItem('KC_REFRESH');
     this.keycloakAuth.logout({ redirectUri: redirectUrl });
   }
 }

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -94,8 +94,12 @@ export class TransomApiClientService  {
    * @param body The body to post to the request.
    */
   postFoiRequest(foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
-    console.count('COUNT: postFoiRequest FUNCTION');
-    console.trace('TRACE: postFoiRequest FUNCTION');
+    console.log(
+      '[TRANSOM LAYER]',
+      new Date().toISOString(),
+      'postFoiRequest called'
+    );
+    console.trace('postFoiRequest FUNCTION');
     const functionName = sendEmailOnly ? "submitFoiRequestEmail" : "submitFoiRequest";
     const url = this.baseUrl + `/fx/${functionName}`;
 

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -94,6 +94,8 @@ export class TransomApiClientService  {
    * @param body The body to post to the request.
    */
   postFoiRequest(foiRequest: FoiRequest, sendEmailOnly?: boolean): Observable<any> {
+    console.count('COUNT: postFoiRequest FUNCTION');
+    console.trace('TRACE: postFoiRequest FUNCTION');
     const functionName = sendEmailOnly ? "submitFoiRequestEmail" : "submitFoiRequest";
     const url = this.baseUrl + `/fx/${functionName}`;
 

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -111,7 +111,8 @@ export class TransomApiClientService  {
     }
 
     const obs = this.http.post(url, body, {
-      headers: this.headers
+      headers: this.headers,
+      observe: 'response'
     });
     return this.handleResponse(obs);
   }

--- a/web/src/app/transom-api-client.service.ts
+++ b/web/src/app/transom-api-client.service.ts
@@ -111,8 +111,7 @@ export class TransomApiClientService  {
     }
 
     const obs = this.http.post(url, body, {
-      headers: this.headers,
-      observe: 'response'
+      headers: this.headers
     });
     return this.handleResponse(obs);
   }

--- a/web/src/app/utils-components/base/base.component.ts
+++ b/web/src/app/utils-components/base/base.component.ts
@@ -74,6 +74,10 @@ export class BaseComponent implements OnInit {
     // }
   }
 
+  goHome() {
+    this.router.navigate([''])
+  }
+
   goSkipForward() {   
     this.foiRouter.progress({ direction: 2 });
   }


### PR DESCRIPTION
To address the issue of duplicate raw requests being created via webform -> a deduplication request redis service is created.

Solution → Create a redis service that hashes rawrequest payload data which is cached for 30mins. Implement this redis service at endpoint where raw requests are created.

Before a raw request is created, verify if new request payload data does not exist in redis cache (where previous rawrequest payloads have been hashed and saved) → if data exists, skip rawrequest creation → if data does not exist, hash and cache the payload to redis and continue with creation of rawrequest. If duplicate exists, FE user on webform app is alerted with a message stating duplicate exsits (after alert is closed -> FE request data is cleared, user is logged out and sent to beginning of webform process), if no duplicate, FE user on webform app continues on with process (payment etc)

If any error occurs with deduplication service (with redis etc) do not mark request as duplicate and add to DB. 

Additionally, added logging to FE and API and some FE fixes to clearing state and blocking user from spamming submit to further stop duplicates (these are minor precautionary changes in addition to the dedupe service.

Finally also adjusted our keycloak logic, specifically for logouts. logoutUser function now takes an arguement to dynamically adjust the redirect url after logout + logout function now ALSO removes session storage keys which were set by our code but never cleared -> leading to bugs where user is still treated as a logged in user if they were to logout and then continue with the request process. 

Related PR - https://github.com/bcgov/foi-flow/pull/6265