### PR TITLE
Ticket 5167: Adjusted request receipt generation (removed playwright and now calling request-managemnet-api)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -9,7 +9,6 @@ COPY package.json package-lock.json ./
 
 # Install the application dependencies
 RUN npm install --legacy-peer-deps --ignore-scripts
-RUN node node_modules/playwright/cli.js install chromium
 
 # Copy the rest of the application code to the working directory
 COPY *.js *.sh *.env ./

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -255,6 +255,7 @@ const generatePDFFromHTML = async (html) => {
       "requestHTML": html
     };
     const response = requestAPI.invokeGenerateRequestPDF(JSON.stringify(data), apiURL);
+    console.log("RES", response)
     
     if (response.status !== 200) {
       console.error(response.data.message);

--- a/api/apiCustomFunctions.js
+++ b/api/apiCustomFunctions.js
@@ -8,26 +8,26 @@ const fs = require('fs');
 const {EmailLayout, ConfirmationEmailLayout, ApplicantEmailLayout} = require('./emailLayout');
 const restifyErrors = require('restify-errors');
 const { RequestAPI } = require('./foiRequestApiService');
-const { chromium } = require('playwright');
+// const { chromium } = require('playwright');
 
 const foiRequestAPIBackend = process.env.FOI_REQUEST_API_BACKEND;
 const foiRequestInbox = process.env.FOI_REQUEST_INBOX;
 const requestAPI = new RequestAPI();
 const MAX_ATTACH_MB = 5;
 const maxAttachBytes = MAX_ATTACH_MB * 1024 * 1024;
-let initializedBrowser = null;
+// let initializedBrowser = null;
 
-const getBrowser = async () => {
-  if (!initializedBrowser) {
-    initializedBrowser = chromium.launch({headless: true});
-  }
-  let browser = await initializedBrowser;
-  if (!browser.isConnected()) {
-    initializedBrowser = chromium.launch({headless: true});
-    browser = await initializedBrowser;
-  }
-  return browser;
-}
+// const getBrowser = async () => {
+//   if (!initializedBrowser) {
+//     initializedBrowser = chromium.launch({headless: true});
+//   }
+//   let browser = await initializedBrowser;
+//   if (!browser.isConnected()) {
+//     initializedBrowser = chromium.launch({headless: true});
+//     browser = await initializedBrowser;
+//   }
+//   return browser;
+// }
 
 const submitFoiRequest = async (server, req, res, next) => {
   console.log(
@@ -53,6 +53,13 @@ const submitFoiRequest = async (server, req, res, next) => {
   };
 
   if (req.files) {
+    // // 5166 WORK START
+    // const requestAttachmentHTML = new EmailLayout().renderEmail(req.params ,req.isAuthorised, req.userDetails);
+    // const requestAttachment = generatePDFFromHTML(requestAttachmentHTML);
+    // //WTF IS REQ.FILES? DICT? LIST?
+    // req.files["RequestReceipt"] = requestAttachment;
+    // // 5166 WORK END
+
     data.params["requestData"].Attachments = convertFilesToBase64(
       req.files,
       maxAttachBytes,
@@ -217,7 +224,7 @@ const sendApplicantEmail = async (req, server, applicantEmail) => {
     
     if (requestReceipt) {
       attachments.push({
-        content: requestReceipt.toString("base64"),
+        content: Buffer.from(requestReceipt).toString("base64"),
         filename: "RequestDetails.pdf",
         encoding: "base64"
       });
@@ -232,24 +239,37 @@ const sendApplicantEmail = async (req, server, applicantEmail) => {
 }
 
 const generatePDFFromHTML = async (html) => {
-  const browser = await getBrowser();
-  const page = await browser.newPage();
+  // const browser = await getBrowser();
+  // const page = await browser.newPage();
   try {
-    await page.setContent(html, {
-      waitUntil: 'networkidle',
-      timeout: 10000,
-    });
-    const pdfBuffer = await page.pdf({
-      format: "Letter",
-    });
+    // await page.setContent(html, {
+    //   waitUntil: 'networkidle',
+    //   timeout: 10000,
+    // });
+    // const pdfBuffer = await page.pdf({
+    //   format: "Letter",
+    // });
 
-    console.log("LARGE FILE?:", pdfBuffer.length > maxAttachBytes);
-    return pdfBuffer;
+    const apiURL = `${foiRequestAPIBackend}/foirawrequest/requestreceipt`;
+    const data = {
+      "requestHTML": html
+    };
+    const response = requestAPI.invokeGenerateRequestPDF(JSON.stringify(data), apiURL);
+    
+    if (response.status !== 200) {
+      console.error(response.data.message);
+      throw Error("Error in generating request receipt pdf");
+    }
+    const pdfBytes = response.data.pdf;
+
+    console.log("LARGE FILE?:", pdfBytes.length > maxAttachBytes);
+    return pdfBytes;
   } catch(e) {
     console.error(e);
-  } finally {
-    await page.close();
-  }
+  } 
+  // finally {
+  //   await page.close();
+  // }
 }
 
 const sendConfirmationEmail = async (req, server, attachmets = []) => {

--- a/api/foiRequestApiService.js
+++ b/api/foiRequestApiService.js
@@ -54,5 +54,15 @@ function RequestAPI() {
        };
        return axios.post(apiUrl, data, axiosConfig);
      };
+
+     this.invokeGenerateRequestPDF = (data, apiUrl) => {
+      const axiosConfig = {
+        headers: {
+          "Content-Type": "application/json",
+        },
+        responseType: "arraybuffer"
+      };
+      return axios.post(apiUrl, data, axiosConfig);
+     }
   };  
   module.exports = { RequestAPI };

--- a/api/package.json
+++ b/api/package.json
@@ -27,7 +27,6 @@
     "jwks-rsa": "^3.1.0",
     "lamejs": "^1.2.1",
     "minimist": ">=1.2.8",
-    "playwright": "1.62.0",
     "streamifier": "^0.1.1",
     "svg-captcha": "^1.4.0",
     "text2wav": "0.0.14",


### PR DESCRIPTION
New logic now calls python request-management-api endpoint that receives HTML data and creates a simple PDF and sends the pdf bytes back via a response.